### PR TITLE
Add employment section

### DIFF
--- a/api/controllers/DocumentsController.js
+++ b/api/controllers/DocumentsController.js
@@ -23,7 +23,7 @@ module.exports = {
     if (valid) {
       // save the model
       req.session.medicalReport.supporting_documents = req.body.supporting_documents;
-      res.redirect(sails.route('conditions'));
+      res.redirect(sails.route('employment'));
     }
   }
 };

--- a/api/controllers/EmploymentController.js
+++ b/api/controllers/EmploymentController.js
@@ -1,0 +1,39 @@
+/**
+ * EmploymentController
+ *
+ * @description :: Server-side actions for handling incoming requests.
+ * @help        :: See https://sailsjs.com/docs/concepts/actions
+ */
+
+module.exports = {
+  index: function (req, res) {
+    /**
+     * If there is a medical report in the session, load it
+     */
+    if (req.session.medicalReport) {
+      if (res.locals.data) {
+        res.locals.data = _.merge(res.locals.data, req.session.medicalReport);
+      } else {
+        res.locals.data = req.session.medicalReport;
+      }
+    }
+
+    res.view('pages/employment');
+  },
+  
+  store: function (req, res) {
+    let valid = req.validate(req, res, require('../schemas/employment.schema'));
+
+    if (valid) {
+      // save the model
+      req.session.medicalReport.stop_work = req.body.stop_work;
+      req.session.medicalReport.date_stopped_work = req.body.date_stopped_work;
+      req.session.medicalReport.return_to_work = req.body.return_to_work;
+      req.session.medicalReport.return_to_work_timeframe = req.body.return_to_work_timeframe;
+      req.session.medicalReport.type_of_work = req.body.type_of_work;
+      req.session.medicalReport.type_of_work_other = req.body.type_of_work_other;
+
+      res.redirect(sails.route('health'));
+    }
+  }
+};

--- a/api/schemas/employment.schema.js
+++ b/api/schemas/employment.schema.js
@@ -1,0 +1,68 @@
+module.exports = {
+  stop_work: {
+    presence: {
+      message: '^Stop working is required',
+      allowEmpty: false,
+    },
+  },
+  date_stopped_work: function (value, attributes) {
+    const stop_work = attributes.stop_work;
+    if (stop_work && stop_work === '1') { 
+      if (value) {
+        return {
+          validateDateFormat: {
+            message: '^Stop work date is incorrectly formatted'
+          },
+          validateDateExists: {
+            message: '^Stop work date is not a valid date'
+          }
+        }
+      }
+      return {
+        presence: {
+          allowEmpty: false,
+          message: '^Stop work date is required if stop work is selected'
+        },
+      }
+    }
+  },
+  return_to_work: {
+    presence: {
+      message: '^Stop working is required',
+      allowEmpty: false,
+    },
+  },
+  return_to_work_timeframe: function (value, attributes) {
+    const return_to_work = attributes.return_to_work;
+    if (return_to_work && return_to_work === '1') {
+      return {
+        presence: {
+          allowEmpty: false,
+          message: '^Return to work timeframe is required if return to work is yes'
+        },
+      }
+    }
+  },
+  type_of_work: function (value, attributes) {
+    const return_to_work = attributes.return_to_work;
+    if (return_to_work && return_to_work === '1') {
+      return {
+        presence: {
+          allowEmpty: false,
+          message: '^Type of work is required if return to work is yes'
+        },
+      }
+    }
+  },
+  type_of_work_other: function (value, attributes) {
+    const type_of_work = attributes.type_of_work;
+    if (type_of_work && type_of_work === '4') {
+      return {
+        presence: {
+          allowEmpty: false,
+          message: '^Other type of work is required if Other selected'
+        },
+      }
+    }
+  },
+}

--- a/config/routes.js
+++ b/config/routes.js
@@ -387,6 +387,31 @@ module.exports.routes = {
       fr: '/fr/expedited'
     }
   },
+  
+  /*
+   * EMPLOYMENT ROUTES
+   */
+  'GET /en/employment': {
+    name: 'employment',
+    controller: 'EmploymentController',
+    action: 'index',
+    lang: 'en',
+    i18n: {
+      en: '/en/employment',
+      fr: '/fr/employment'
+    }
+  },
+
+  'POST /en/employment': {
+    name: 'employment.store',
+    controller: 'EmploymentController',
+    action: 'store',
+    lang: 'en',
+    i18n: {
+      en: '/en/employment',
+      fr: '/fr/employment'
+    }
+  },
 
   // example route with params
   'GET /en/product/:id': {

--- a/views/pages/employment.njk
+++ b/views/pages/employment.njk
@@ -1,0 +1,31 @@
+{% extends "layouts/layout.njk" %}
+
+{% block content %}
+
+    <h1>{{ __('section6.title') }}</h1>
+
+    <div>
+        <p>
+            {{ __('section6.instructions') }}
+        </p>
+
+        <form method="post">
+            <input type="hidden" name="_csrf" value="{{ _csrf }}">
+
+            {{ radioButtons('stop_work', { '1':'Yes','2':'No','3':'section6.stop_work_not_discussed'}, data.stop_work, 'section6.stop_work_question', errors) }}
+
+            {{ textInput('date_stopped_work', 'section6.stop_work_recommended', { hint: 'year_month_date_format', required: true }) }}
+
+            {{ radioButtons('return_to_work', { '1':'section6.return_work_yes','2':'section6.return_work_no','3':'section6.return_work_unknown'}, data.return_to_work, 'section6.return_work_question', errors) }}
+
+            {{ radioButtons('return_to_work_timeframe', { '1':'section6.return_work_6_to_12_months','2':'section6.return_work_12_to_24_months','3':'section6.return_work_more_than_24_months','4':'Unknown'}, data.return_to_work_timeframe, 'section6.return_work_timeframe_question', errors) }}
+
+            {{ radioButtons('type_of_work', { '1':'section6.type_work_usual','2':'section6.type_work_modified','3':'section6.type_work_training','4':'section6.type_work_other'}, data.type_of_work, 'section6.type_work_question', errors) }}
+
+            {{ textInput('type_of_work_other', 'section6.type_work_question') }}
+
+            {{ formButtons() }}
+        </form>
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
Adds the Employment section back in.

This wasn't linked up in the previous version. To test, fill out the Personal form, then navigate directly to: `/en/employment`. You will be redirected to `Overall Health` section when complete.