### PR TITLE
Make Heroku stack 'container'

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,11 +1,4 @@
 {
     "name": "cppd-medical-report-starter",
-    "description": "",
-    "formation": {},
-    "addons": [],
-    "buildpacks": [
-        {
-            "url": "heroku/nodejs"
-        }
-    ]
+    "stack": "container"
 }

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,4 +2,4 @@ build:
   docker:
     web: Dockerfile
 run:
-  web: PORT=80 sails lift
+  web: sails lift --port=$PORT


### PR DESCRIPTION
Based on a response to a Heroku support issue. Sets the stack and passes Heroku's randomly assigned port.