### PR TITLE
Returns the auto-select if only one condition

### DIFF
--- a/api/controllers/AddMedicationController.js
+++ b/api/controllers/AddMedicationController.js
@@ -7,6 +7,7 @@
 
 const {
   conditionReducer,
+  oneAttribute,
 } = require('../utils/condition.mapper');
 
 module.exports = {
@@ -15,7 +16,8 @@ module.exports = {
     const conditionList = conditionReducer(data.conditions);
 
     res.view('pages/medications/add', {
-      conditionList: conditionList
+      conditionList: conditionList,
+      oneValue: oneAttribute(conditionList)
     });
   },
 

--- a/api/controllers/AddTreatmentController.js
+++ b/api/controllers/AddTreatmentController.js
@@ -7,6 +7,7 @@
 
 const {
   conditionReducer,
+  oneAttribute,
 } = require('../utils/condition.mapper');
 
 module.exports = {
@@ -15,7 +16,8 @@ module.exports = {
     const conditionList = conditionReducer(data.conditions);
 
     res.view('pages/treatments/add', {
-      conditionList: conditionList
+      conditionList: conditionList,
+      oneValue: oneAttribute(conditionList)
     });
   },
 

--- a/api/controllers/EditMedicationController.js
+++ b/api/controllers/EditMedicationController.js
@@ -7,6 +7,7 @@
 
 const {
   conditionReducer,
+  oneAttribute,
 } = require('../utils/condition.mapper');
 
 module.exports = {
@@ -28,7 +29,8 @@ module.exports = {
     res.view('pages/medications/edit', {
       id: req.params.id,
       medication: medication,
-      conditionList: conditionList
+      conditionList: conditionList,
+      oneValue: oneAttribute(conditionList)
     });
   },
 

--- a/api/controllers/EditTreatmentController.js
+++ b/api/controllers/EditTreatmentController.js
@@ -7,6 +7,7 @@
 
 const {
   conditionReducer,
+  oneAttribute,
 } = require('../utils/condition.mapper');
 
 module.exports = {
@@ -28,7 +29,8 @@ module.exports = {
     res.view('pages/treatments/edit', {
       id: req.params.id,
       treatment: treatment,
-      conditionList: conditionList
+      conditionList: conditionList,
+      oneValue: oneAttribute(conditionList)
     });
   },
 


### PR DESCRIPTION
## What this does
Brings back the functionality where if there is only one Condition, the Medication and Treatment forms auto-select that Condition.

## To test
- Fill in the Personal form
- Skip to Conditions and add one Condition
- Go to Add Medications - note the Condition is already selected
- Go to Add Treatments - note the Condition is already selected