### PR TITLE
Add conditional validation for unknown fields

### DIFF
--- a/api/schemas/condition.schema.js
+++ b/api/schemas/condition.schema.js
@@ -22,8 +22,16 @@ module.exports = {
       message: '^errors.condition_outlook_required'
     }
   },
-  condition_outlook_unknown: {
-    // conditional
+  condition_outlook_unknown: function (value, attributes) {
+    const condition_outlook = attributes.condition_outlook;
+    if (condition_outlook && condition_outlook === '4') {
+      return {
+        presence: {
+          allowEmpty: false,
+          message: '^errors.condition_outlook_unknown'
+        }
+      }
+    }
   },
   condition_last: {
     presence: {
@@ -36,7 +44,15 @@ module.exports = {
       message: '^errors.symptoms_occur_required'
     }
   },
-  symptoms_occur_unknown: {
-    // conditional
+  symptoms_occur_unknown: function (value, attributes) {
+    const symptoms_occur = attributes.symptoms_occur;
+    if (symptoms_occur && symptoms_occur === '3') {
+      return {
+        presence: {
+          allowEmpty: false,
+          message: '^errors.symptoms_occur_uknown_required'
+        }
+      }
+    }
   }
 };

--- a/api/schemas/condition.schema.js
+++ b/api/schemas/condition.schema.js
@@ -50,7 +50,7 @@ module.exports = {
       return {
         presence: {
           allowEmpty: false,
-          message: '^errors.symptoms_occur_uknown_required'
+          message: '^errors.symptoms_occur_unknown_required'
         }
       }
     }

--- a/api/utils/condition.mapper.js
+++ b/api/utils/condition.mapper.js
@@ -9,7 +9,7 @@
  *       name_of_condition: "",
  *       symptoms_began: "",
  *       symptoms_occur: "",
- *       symptoms_occur_uknown: ""
+ *       symptoms_occur_unknown: ""
  *    }
  * ]
  * ... and returns an object like so:

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -223,7 +223,7 @@
   "errors.supporting_documents_required": "Supporting Documents is required",
   "errors.symptoms_began.length": "Symptoms began is required",
   "errors.symptoms_occur_required": "Symptoms occur is required",
-  "errors.symptoms_occur_uknown_required": "Tell us why the frequency of symptoms is unknown",
+  "errors.symptoms_occur_unknown_required": "Tell us why the frequency of symptoms is unknown",
   "errors.treatment_end_date.length": "Treatment end date is required",
   "errors.treatment_frequency.length": "Treatment Frequency is required",
   "errors.treatment_results.length": "Treatment results is required",

--- a/config/locales/fr.json
+++ b/config/locales/fr.json
@@ -223,7 +223,7 @@
   "errors.supporting_documents_required": "erreur",
   "errors.symptoms_began.length": "erreur",
   "errors.symptoms_occur_required": "erreur",
-  "errors.symptoms_occur_uknown_required": "erreur",
+  "errors.symptoms_occur_unknown_required": "erreur",
   "errors.treatment_end_date.length": "errors.treatment_end_date.length",
   "errors.treatment_frequency.length": "errors.treatment_frequency.length",
   "errors.treatment_results.length": "errors.treatment_results.length",

--- a/views/pages/conditions/condition-form.njk
+++ b/views/pages/conditions/condition-form.njk
@@ -18,6 +18,6 @@
     {{ radioButtons('symptoms_occur', { '1':'add_condition.symptoms_occur_periodically', '2':'add_condition.symptoms_occur_continuously', '3':'add_condition.symptoms_occur_unknown'}, condition.symptoms_occur, 'add_condition.symptoms_occur', errors, { required: true }) }}
 
     <div id="unknown_symptoms_occur_details" class="ml-4">
-        {{ textArea('symptoms_occur_uknown', 'add_condition.symptoms_occur_unknown_label', { required: true, value: condition.symptoms_occur_uknown }) }}
+        {{ textArea('symptoms_occur_unknown', 'add_condition.symptoms_occur_unknown_label', { required: true, value: condition.symptoms_occur_unknown }) }}
     </div>
 {% endmacro %}


### PR DESCRIPTION
## What this does
- Adds conditional validation for "Unknown" fields on Condition forms
- Fixes type in field name that was causing validation error msg to not appear correctly

## To test
- Fill out the Personal form
- Skip to `/en/conditions`
- Fill out the form, make sure to select "Unknown" for the two questions where that's an option
- Submit and notice the validation messages

This goes well with #43 