### PR TITLE
Add dotenv for env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+SESSION_ADAPTER="@sailshq/connect-redis"

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 SESSION_ADAPTER="@sailshq/connect-redis"
+SESSION_ADAPTER_URL="redis://localhost:6379"

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ lib-cov
 *.out
 *.pid
 
+.env

--- a/app.js
+++ b/app.js
@@ -49,6 +49,7 @@ try {
   return;
 }//-•
 
+require('dotenv').config();
 
 // Start server
 sails.lift(rc('sails'));

--- a/config/session.js
+++ b/config/session.js
@@ -20,6 +20,10 @@ module.exports.session = {
   ***************************************************************************/
   secret: '75ecc460b1d5d821b1549f98641fac3d',
 
+  /**
+   * Set the Sesssion Adapter using the env variable (defaults to null|memory)
+   */
+  adapter: process.env.SESSION_ADAPTER || null,
 
   /***************************************************************************
   *                                                                          *

--- a/config/session.js
+++ b/config/session.js
@@ -24,6 +24,8 @@ module.exports.session = {
    * Set the Sesssion Adapter using the env variable (defaults to null|memory)
    */
   adapter: process.env.SESSION_ADAPTER || null,
+  
+  url: process.env.SESSION_ADAPTER_URL || 'redis://localhost:6379',
 
   /***************************************************************************
   *                                                                          *

--- a/package-lock.json
+++ b/package-lock.json
@@ -3778,6 +3778,11 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "dottie": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "connect-flash": "^0.1.1",
     "consolidate": "^0.15.1",
     "continuation-local-storage": "^3.2.1",
+    "dotenv": "^8.2.0",
     "grunt": "1.0.4",
     "nunjucks": "^3.2.0",
     "pg": "^7.15.0",


### PR DESCRIPTION
## What this does
- Adds dotenv package for environment variables
- Sets the Session Adapter using an environment variable
- Adds an .env.example file

## To test
The only .env variable currently implemented is for the Session Adapter. Using Redis for session storage will allow session data to persist across application restarts, helpful in testing.

- If you haven't already, make sure you have redis running locally (or bring up in a container if using docker-compose workflow).
- Copy .env.example to .env
- Restart application
- You should now be using Redis for session storage. To confirm:
  - Fill out the personal form
  - Navigate back to the personal form, data is still there
  - Restart the app
  - Reload personal form, data is still there