### PR TITLE
Invitation page navigates to dashboard

### DIFF
--- a/api/controllers/MedicalProfessionalController.js
+++ b/api/controllers/MedicalProfessionalController.js
@@ -29,7 +29,7 @@ module.exports = {
 
       if (ok) {
         req.session.medicalReport = getApplication(applicationCode);
-        return res.redirect(sails.route('relationship'));
+        return res.redirect(sails.route('dashboard'));
       }
 
       req.flash('error', 'errors.no_application_found');


### PR DESCRIPTION
# Description

The doctor invitation code screen currently routes to the relationship page, but it should go to the dashboard. This fixes that.

# Test instructions

1. Launch the application, and fill out all the applicant sections (personal information, consent)
1. Grab the invitation code from the bottom of the page
1. Go to `/en/doctor`
1. Enter the invitation code and the birthdate you had entered previously
1. Should direct to the dashboard page