### PR TITLE
Reset session at the start of an application

### DIFF
--- a/api/controllers/StartController.js
+++ b/api/controllers/StartController.js
@@ -7,6 +7,7 @@
 
 module.exports = {
   index: function(req, res) {
+    req.session.medicalReport = {};
     res.view('pages/start');
   }
 };


### PR DESCRIPTION
# Description

Clears the session on the start page, which is both helpful in the situation where someone may be filling it out on a shared computer and for research sessions.

# Test

1. Go to the application
1. Fill out the personal information and submit
1. Change the URL `/en/personal` and notice information is still there
1. Change the URL to `/en/start`
1. Change the URL to `/en/personal` and notice that information is cleared and it is blank

# Notes

- Not a design change, just a dev review requested