### PR TITLE
Download Sessions endpoint

### DIFF
--- a/api/controllers/SessionsController.js
+++ b/api/controllers/SessionsController.js
@@ -1,0 +1,31 @@
+/**
+ * SessionsController
+ *
+ * @description :: Server-side actions for handling incoming requests.
+ * @help        :: See https://sailsjs.com/docs/concepts/actions
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+  index: function (req, res) {
+
+    let directory = path.resolve(__dirname, '../../sessions');
+    console.log(directory);
+
+    fs.readdir(directory, (err, files) => {
+      if (!err) {
+        console.log(files);
+        res.view('pages/sessions', {
+          files: files
+        });
+      }
+    });
+  },
+
+  download: function (req, res) {
+
+  }
+};
+

--- a/api/controllers/SessionsController.js
+++ b/api/controllers/SessionsController.js
@@ -12,11 +12,10 @@ module.exports = {
   index: function (req, res) {
 
     let directory = path.resolve(__dirname, '../../sessions');
-    console.log(directory);
 
     fs.readdir(directory, (err, files) => {
       if (!err) {
-        console.log(files);
+        _.pull(files, '.gitignore');
         res.view('pages/sessions', {
           files: files
         });
@@ -25,7 +24,21 @@ module.exports = {
   },
 
   download: function (req, res) {
+    const filename = req.params.session;
+    const sessionFile = path.resolve(__dirname, '../../sessions/' + filename);
+    
+    var SkipperDisk = require('skipper-disk');
+    var fileAdapter = SkipperDisk(/* optional opts */);
 
+    // set the filename to the same file as the user uploaded
+    res.set('Content-disposition', 'attachment; filename=' + filename);
+
+    // Stream the file down
+    fileAdapter.read(sessionFile)
+    .on('error', (err) => {
+      return res.serverError(err);
+    })
+    .pipe(res);
   }
 };
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -547,4 +547,15 @@ module.exports.routes = {
       fr: '/fr/sessions'
     }
   },
+
+  'GET /en/sessions/:session/download': {
+    name: 'sessions.download',
+    controller: 'SessionsController',
+    action: 'download',
+    lang: 'en',
+    i18n: {
+      en: '/en/sessions/:session/download',
+      fr: '/fr/sessions/:session/download'
+    }
+  },
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -20,7 +20,7 @@ module.exports.routes = {
    *                                                                          *
    ***************************************************************************/
 
-  ... require('./routes/functional'),
+  ...require('./routes/functional'),
 
   '/': '/en/start', // redirect to start
 
@@ -531,6 +531,20 @@ module.exports.routes = {
     i18n: {
       en: '/en/confirmation',
       fr: '/fr/confirmation'
+    }
+  },
+
+  /**
+   * SESSIONS ROUTES
+   */
+  'GET /en/sessions': {
+    name: 'sessions',
+    controller: 'SessionsController',
+    action: 'index',
+    lang: 'en',
+    i18n: {
+      en: '/en/sessions',
+      fr: '/fr/sessions'
     }
   },
 };

--- a/views/pages/sessions.njk
+++ b/views/pages/sessions.njk
@@ -1,0 +1,12 @@
+{% extends "layouts/layout.njk" %}
+
+{% block content %}
+  <h1>Sessions</h1>
+
+  <ul>
+    {% for file in files %}
+      <li><a href="">{{ file }}</a></li>
+    {% endfor %}
+  </ul>
+
+{% endblock %}

--- a/views/pages/sessions.njk
+++ b/views/pages/sessions.njk
@@ -5,7 +5,7 @@
 
   <ul>
     {% for file in files %}
-      <li><a href="">{{ file }}</a></li>
+      <li><a href="{{ route('sessions.download', { session: file }) }}">{{ file }}</a></li>
     {% endfor %}
   </ul>
 


### PR DESCRIPTION
# What this does

Enables downloading of session data. Note that this just renders out the contents of the `sessions` folder. Other than pulling the `.gitignore` file, we don't do any other processing, so you may have old sessions objects with timestamps for names if working locally.

## To test

- Start one or more sessions
- Navigate to `/en/sessions`
- You'll see a list of the files in the `sessions` folder
- Click one to download it
