### PR TITLE
Allow empty Medications and Treatments

### DIFF
--- a/api/controllers/DashboardController.js
+++ b/api/controllers/DashboardController.js
@@ -7,14 +7,28 @@
 
 const validate = require('../hooks/validate/validator');
 
+function checkMedications(report) {
+  if (report.patientMedications === 'no') {
+    return true;
+  }
+  return isArrayValid(report.medications, require('../schemas/medication.schema'));
+}
+
+function checkTreatements(report) {
+  if (report.patientTreatments === 'no') {
+    return true;
+  }
+  return isArrayValid(report.treatments, require('../schemas/treatment.schema'));
+}
+
 function getSectionsCompleted(report) {
   return {
     personal: isValid(report, require('../schemas/relationship.schema')),
     expedited : isValid(report, require('../schemas/expedited.schema')),
     functional: isValid(report,require('../schemas/functional.schema')),
     conditions: isArrayValid(report.conditions, require('../schemas/condition.schema')),
-    medications: isArrayValid(report.medications, require('../schemas/medication.schema')),
-    treatments: isArrayValid(report.treatments, require('../schemas/treatment.schema')),
+    medications: checkMedications(report),
+    treatments: checkTreatements(report),
     overallHealth : isValid(report, require('../schemas/health.schema')),
     futureWork: isValid(report, require('../schemas/work.schema')),
 
@@ -45,6 +59,10 @@ function isValid(obj, schema) {
 
 function isArrayValid(arr, schema) {
   if (arr === undefined) {
+    return false;
+  }
+
+  if (arr.length === 0) {
     return false;
   }
 

--- a/api/controllers/MedicationsController.js
+++ b/api/controllers/MedicationsController.js
@@ -5,14 +5,35 @@
  * @help        :: See https://sailsjs.com/docs/concepts/actions
  */
 
+const dataStore = require('../utils/DataStore');
+
 module.exports = {
   index: function (req, res) {
-    if (!_.has(req.session.medicalReport, 'medications')) {
-      return res.redirect(sails.route('medications.add'));
-    }
-
     res.view('pages/medications/index', {
       data: req.session.medicalReport
     });
+  },
+
+  save: function (req, res) {
+    let valid = req.validate(req, res, {
+      patientMedications: {
+        presence: {
+          allowEmpty: false,
+          message: '^Please make a selection'
+        }
+      },
+    });
+
+    if (valid) {
+      // save the model
+      req.session.medicalReport.patientMedications = req.body.patientMedications;
+      dataStore.storeMedicalReport(req.session.medicalReport);
+
+      if (req.body.patientMedications === 'yes') {
+        return res.redirect(sails.route('medications.add'));
+      }
+
+      return res.redirect(sails.route('dashboard'));
+    }
   }
 };

--- a/api/controllers/TreatmentsController.js
+++ b/api/controllers/TreatmentsController.js
@@ -5,14 +5,35 @@
  * @help        :: See https://sailsjs.com/docs/concepts/actions
  */
 
+const dataStore = require('../utils/DataStore');
+
 module.exports = {
   index: function (req, res) {
-    if (!_.has(req.session.medicalReport, 'treatments')) {
-      return res.redirect(sails.route('treatments.add'));
-    }
-
     res.view('pages/treatments/index', {
       data: req.session.medicalReport
     });
+  },
+
+  save: function (req, res) {
+    let valid = req.validate(req, res, {
+      patientTreatments: {
+        presence: {
+          allowEmpty: false,
+          message: '^Please make a selection'
+        }
+      },
+    });
+
+    if (valid) {
+      // save the model
+      req.session.medicalReport.patientTreatments = req.body.patientTreatments;
+      dataStore.storeMedicalReport(req.session.medicalReport);
+
+      if (req.body.patientTreatments === 'yes') {
+        return res.redirect(sails.route('treatments.add'));
+      }
+
+      return res.redirect(sails.route('dashboard'));
+    }
   }
 };

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -511,6 +511,5 @@
 	"section6.more_details": "Provide more details where possible",
 	"dashboard.overall-health": "Patient's Overall Health",
 	"dashboard.expedited-processing": "Expedited processing for terminal and grave conditions",
-	"conditions.incomplete": "Incomplete",
-	"conditions.patient_treatments": "conditions.patient_treatments"
+	"conditions.incomplete": "Incomplete"
 }

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -186,7 +186,6 @@
 	"conditions.medical_conditions": "Medical conditions",
 	"conditions.next_medications": "Next: Medications",
 	"conditions.patient": "Patient:",
-	"conditions.patient_conditions": "Is your patient currently receiving medication for their condition(s)?",
 	"conditions.remove_condition": "Remove condition",
 	"conditions.save_condition": "Save condition",
 	"conditions.symptoms_began": "Symptoms began: ",
@@ -278,6 +277,7 @@
 	"medications.remove_medication": "Remove medication",
 	"medications.save_medication": "Save and add another medication",
 	"medications.save_and_return": "Save and return",
+	"medications.patient_medications": "Is your patient currently receiving medication for their condition(s)?",
 	"more than 1 year": "more than 1 year",
 	"ne: ": "ne: ",
 	"next": "Next",
@@ -421,6 +421,7 @@
 	"treatments.save_and_return": "Save and return",
 	"treatments.title": "Treatments",
 	"treatments.treatments": "Treatments",
+	"treatments.patient_treatments": "Is your patient currently receiving treatment for their condition(s)?",
 	"unknown": "unknown",
 	"unknown (* If prognosis and/or frequency is unknown, please explain why in <b>Section 7 - Other relevant information.</b>)": "unknown (* If prognosis and/or frequency is unknown, please explain why in <b>Section 7 - Other relevant information.</b>)",
 	"unknown (* If prognosis and/or frequency is unknown, please explain why in Section 7 - Other relevant information.)": "unknown (* If prognosis and/or frequency is unknown, please explain why in Section 7 - Other relevant information.)",
@@ -510,5 +511,6 @@
 	"section6.more_details": "Provide more details where possible",
 	"dashboard.overall-health": "Patient's Overall Health",
 	"dashboard.expedited-processing": "Expedited processing for terminal and grave conditions",
-	"conditions.incomplete": "Incomplete"
+	"conditions.incomplete": "Incomplete",
+	"conditions.patient_treatments": "conditions.patient_treatments"
 }

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -186,6 +186,7 @@
 	"conditions.medical_conditions": "Medical conditions",
 	"conditions.next_medications": "Next: Medications",
 	"conditions.patient": "Patient:",
+	"conditions.patient_conditions": "Is your patient currently receiving medication for their condition(s)?",
 	"conditions.remove_condition": "Remove condition",
 	"conditions.save_condition": "Save condition",
 	"conditions.symptoms_began": "Symptoms began: ",

--- a/config/routes.js
+++ b/config/routes.js
@@ -185,6 +185,17 @@ module.exports.routes = {
     }
   },
 
+  'POST /en/medications': {
+    name: 'medications.save',
+    controller: 'MedicationsController',
+    action: 'save',
+    lang: 'en',
+    i18n: {
+      en: '/en/medications',
+      fr: '/fr/medications'
+    }
+  },
+
   'GET /en/medications/add': {
     name: 'medications.add',
     controller: 'AddMedicationController',

--- a/config/routes.js
+++ b/config/routes.js
@@ -265,6 +265,17 @@ module.exports.routes = {
     }
   },
 
+  'POST /en/treatments': {
+    name: 'treatments.save',
+    controller: 'TreatmentsController',
+    action: 'save',
+    lang: 'en',
+    i18n: {
+      en: '/en/treatments',
+      fr: '/fr/treatments'
+    }
+  },
+
   'GET /en/treatments/add': {
     name: 'treatments.add',
     controller: 'AddTreatmentController',

--- a/views/pages/medications/index.njk
+++ b/views/pages/medications/index.njk
@@ -8,7 +8,7 @@
 
     {% if (not data.medications.length) %}
         <form method="post">
-            {{ radioButtons('patientMedications', { 'yes':'Yes', 'no':'No' }, data.patientMedications, 'conditions.patient_conditions', errors, { required: true }) }}
+            {{ radioButtons('patientMedications', { 'yes':'Yes', 'no':'No' }, data.patientMedications, 'medications.patient_medications', errors, { required: true }) }}
             <div class="mt-4 w-1/3">
                 <button type="submit">{{ __('Save') }}</button>
             </div>

--- a/views/pages/medications/index.njk
+++ b/views/pages/medications/index.njk
@@ -6,45 +6,54 @@
     
     <h1 class="border-gray-400 border-b">{{ __('medication.title') }}<br/> <span class="text-base">{{ __('patient_name')}} {{ patientName(data) }}</span></h1>
 
-    <div class="mt-10">
-        <h2 class="text-2xl mb-4">{{ __('medications.medications') }}</h2>
+    {% if (not data.medications.length) %}
+        <form method="post">
+            {{ radioButtons('patientMedications', { 'yes':'Yes', 'no':'No' }, data.patientMedications, 'conditions.patient_conditions', errors, { required: true }) }}
+            <div class="mt-4 w-1/3">
+                <button type="submit">{{ __('Save') }}</button>
+            </div>
+        </form>
+    {% endif %}
 
-        {% for medication in data.medications %}  
-            <div class="flex border-t border-b">
-                <div class="w-1/2">
-                    <p>{{ medication.medicationName }}</p>
-                    <p class="text-base">{{ medication.medicationDosage }}</p>
-                    <p class="text-base">{{ medication.medicationStartDate }} - {{ medication.medicationEndDate }}</p>
+    {% if (data.medications.length) %}
+        <div class="mt-10">
+            {% for medication in data.medications %}  
+                <div class="flex border-t border-b">
+                    <div class="w-1/2">
+                        <p>{{ medication.medicationName }}</p>
+                        <p class="text-base">{{ medication.medicationDosage }}</p>
+                        <p class="text-base">{{ medication.medicationStartDate }} - {{ medication.medicationEndDate }}</p>
+                    </div>
+                    <div class="w-1/2">
+                        <a href="{{ route('medications.edit', { id: loop.index }) }}" class="text-sm">
+                            <svg class="w-4 h-4 inline fill-current mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M17.561 2.439c-1.442-1.443-2.525-1.227-2.525-1.227L8.984 7.264 2.21 14.037 1.2 18.799l4.763-1.01 6.774-6.771 6.052-6.052c-.001 0 .216-1.083-1.228-2.527zM5.68 17.217l-1.624.35a3.71 3.71 0 0 0-.69-.932 3.742 3.742 0 0 0-.932-.691l.35-1.623.47-.469s.883.018 1.881 1.016c.997.996 1.016 1.881 1.016 1.881l-.471.468z"/></svg>
+                            {{ __('medications.edit_medication') }}<span class="sr-only"> {{ medication.medicationName }}</span>
+                        </a><br>
+                        <form action="{{ route('medications.delete', { id: loop.index }) }}" method="POST" class="mt-0">
+                            <input type="hidden" name="_csrf" value="{{ _csrf }}">
+                            <a href="#" role="button" onclick="this.parentNode.submit();" class="text-sm">
+                                <svg class="w-4 h-4 inline fill-current mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M10 1.6a8.4 8.4 0 100 16.8 8.4 8.4 0 000-16.8zm5 9.4H5V9h10v2z"/></svg>
+                                {{ __('medications.remove_medication' )}}<span class="sr-only"> {{ medication.medicationName }}</span>
+                            </a>
+                        </form>
+                    </div>
                 </div>
-                <div class="w-1/2">
-                    <a href="{{ route('medications.edit', { id: loop.index }) }}" class="text-sm">
-                        <svg class="w-4 h-4 inline fill-current mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M17.561 2.439c-1.442-1.443-2.525-1.227-2.525-1.227L8.984 7.264 2.21 14.037 1.2 18.799l4.763-1.01 6.774-6.771 6.052-6.052c-.001 0 .216-1.083-1.228-2.527zM5.68 17.217l-1.624.35a3.71 3.71 0 0 0-.69-.932 3.742 3.742 0 0 0-.932-.691l.35-1.623.47-.469s.883.018 1.881 1.016c.997.996 1.016 1.881 1.016 1.881l-.471.468z"/></svg>
-                        {{ __('medications.edit_medication') }}<span class="sr-only"> {{ medication.medicationName }}</span>
-                    </a><br>
-                    <form action="{{ route('medications.delete', { id: loop.index }) }}" method="POST" class="mt-0">
-                        <input type="hidden" name="_csrf" value="{{ _csrf }}">
-                        <a href="#" role="button" onclick="this.parentNode.submit();" class="text-sm">
-                            <svg class="w-4 h-4 inline fill-current mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M10 1.6a8.4 8.4 0 100 16.8 8.4 8.4 0 000-16.8zm5 9.4H5V9h10v2z"/></svg>
-                            {{ __('medications.remove_medication' )}}<span class="sr-only"> {{ medication.medicationName }}</span>
-                        </a>
-                    </form>
+            {% endfor %}
+
+            <div class="mt-4">
+                <a href="{{ route('medications.add') }}" class="text-sm">
+                    <svg class="h-4 w-4 inline fill-current mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+                        <path d="M16 10c0 .553-.048 1-.601 1H11v4.399c0 .552-.447.601-1 .601-.553 0-1-.049-1-.601V11H4.601C4.049 11 4 10.553 4 10c0-.553.049-1 .601-1H9V4.601C9 4.048 9.447 4 10 4c.553 0 1 .048 1 .601V9h4.399c.553 0 .601.447.601 1z"/>
+                    </svg>
+                    {{ __('medications.add_a_medication') }}
+                </a>
+            </div>
+
+            <div class="w-full">
+                <div class="w-1/3">
+                    <a href="{{ route('dashboard') }}" class="button-link">{{ __('return_to_dashboard') }}</a>
                 </div>
             </div>
-        {% endfor %}
-
-        <div class="mt-4">
-            <a href="{{ route('medications.add') }}" class="text-sm">
-                <svg class="h-4 w-4 inline fill-current mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-                    <path d="M16 10c0 .553-.048 1-.601 1H11v4.399c0 .552-.447.601-1 .601-.553 0-1-.049-1-.601V11H4.601C4.049 11 4 10.553 4 10c0-.553.049-1 .601-1H9V4.601C9 4.048 9.447 4 10 4c.553 0 1 .048 1 .601V9h4.399c.553 0 .601.447.601 1z"/>
-                </svg>
-                {{ __('medications.add_a_medication') }}
-            </a>
         </div>
-
-        <div class="w-full">
-          <div class="w-1/3">
-            <a href="{{ route('dashboard') }}" class="button-link">{{ __('return_to_dashboard') }}</a>
-          </div>
-      </div>
-    </div>
+    {% endif %}
 {% endblock %}

--- a/views/pages/treatments/index.njk
+++ b/views/pages/treatments/index.njk
@@ -6,45 +6,54 @@
     
     <h1 class="border-gray-400 border-b">{{ __('treatments.title') }}<br/> <span class="text-base">{{ __('patient_type')}} {{ patientName(data) }}</span></h1>
 
-    <div class="mt-10">
-        <h2 class="text-2xl mb-4">{{ __('treatments.treatments') }}</h2>
+    {% if (not data.treatments.length) %}
+        <form method="post">
+            {{ radioButtons('patientTreatments', { 'yes':'Yes', 'no':'No' }, data.patientTreatments, 'treatments.patient_treatments', errors, { required: true }) }}
+            <div class="mt-4 w-1/3">
+                <button type="submit">{{ __('Save') }}</button>
+            </div>
+        </form>
+    {% endif %}
 
-        {% for treatment in data.treatments %}  
-            <div class="flex border-t border-b">
-                <div class="w-1/2">
-                    <p>{{ treatment.treatmentType }}</p>
-                    <p class="text-base">{{ treatment.treatmentStartDate }}</p>
+    {% if (data.treatments.length) %}
+        <div class="mt-10">
+            {% for treatment in data.treatments %}  
+                <div class="flex border-t border-b">
+                    <div class="w-1/2">
+                        <p>{{ treatment.treatmentType }}</p>
+                        <p class="text-base">{{ treatment.treatmentStartDate }}</p>
+                    </div>
+                    <div class="w-1/2">
+                        <a href="{{ route('treatments.edit', { id: loop.index }) }}" class="text-sm">
+                            <svg class="w-4 h-4 inline fill-current mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M17.561 2.439c-1.442-1.443-2.525-1.227-2.525-1.227L8.984 7.264 2.21 14.037 1.2 18.799l4.763-1.01 6.774-6.771 6.052-6.052c-.001 0 .216-1.083-1.228-2.527zM5.68 17.217l-1.624.35a3.71 3.71 0 0 0-.69-.932 3.742 3.742 0 0 0-.932-.691l.35-1.623.47-.469s.883.018 1.881 1.016c.997.996 1.016 1.881 1.016 1.881l-.471.468z"/></svg>
+                            {{ __('treatments.edit') }}<span class="sr-only"> {{ treatment.type }}</span>
+                        </a><br>
+                        <form action="{{ route('treatments.delete', { id: loop.index }) }}" method="POST" class="mt-0">
+                            <input type="hidden" name="_csrf" value="{{ _csrf }}">
+                            <a href="#" role="button" onclick="this.parentNode.submit();" class="text-sm">
+                                <svg class="w-4 h-4 inline fill-current mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M10 1.6a8.4 8.4 0 100 16.8 8.4 8.4 0 000-16.8zm5 9.4H5V9h10v2z"/></svg>
+                                {{ __('treatments.remove_treatment' )}}<span class="sr-only"> {{ treatment.type }}</span>
+                            </a>
+                        </form>
+                    </div>
                 </div>
-                <div class="w-1/2">
-                    <a href="{{ route('treatments.edit', { id: loop.index }) }}" class="text-sm">
-                        <svg class="w-4 h-4 inline fill-current mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M17.561 2.439c-1.442-1.443-2.525-1.227-2.525-1.227L8.984 7.264 2.21 14.037 1.2 18.799l4.763-1.01 6.774-6.771 6.052-6.052c-.001 0 .216-1.083-1.228-2.527zM5.68 17.217l-1.624.35a3.71 3.71 0 0 0-.69-.932 3.742 3.742 0 0 0-.932-.691l.35-1.623.47-.469s.883.018 1.881 1.016c.997.996 1.016 1.881 1.016 1.881l-.471.468z"/></svg>
-                        {{ __('treatments.edit') }}<span class="sr-only"> {{ treatment.type }}</span>
-                    </a><br>
-                    <form action="{{ route('treatments.delete', { id: loop.index }) }}" method="POST" class="mt-0">
-                        <input type="hidden" name="_csrf" value="{{ _csrf }}">
-                        <a href="#" role="button" onclick="this.parentNode.submit();" class="text-sm">
-                            <svg class="w-4 h-4 inline fill-current mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M10 1.6a8.4 8.4 0 100 16.8 8.4 8.4 0 000-16.8zm5 9.4H5V9h10v2z"/></svg>
-                            {{ __('treatments.remove_treatment' )}}<span class="sr-only"> {{ treatment.type }}</span>
-                        </a>
-                    </form>
+            {% endfor %}
+
+            <div class="mt-4">
+                <a href="{{ route('treatments.add') }}" class="text-sm">
+                    <svg class="h-4 w-4 inline fill-current mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+                        <path d="M16 10c0 .553-.048 1-.601 1H11v4.399c0 .552-.447.601-1 .601-.553 0-1-.049-1-.601V11H4.601C4.049 11 4 10.553 4 10c0-.553.049-1 .601-1H9V4.601C9 4.048 9.447 4 10 4c.553 0 1 .048 1 .601V9h4.399c.553 0 .601.447.601 1z"/>
+                    </svg>
+                    {{ __('treatments.add_a_treatment') }}
+                </a>
+            </div>
+
+
+            <div class="w-full">
+                <div class="w-1/3">
+                    <a href="{{ route('dashboard') }}" class="button-link">{{ __('return_to_dashboard') }}</a>
                 </div>
             </div>
-        {% endfor %}
-
-        <div class="mt-4">
-            <a href="{{ route('treatments.add') }}" class="text-sm">
-                <svg class="h-4 w-4 inline fill-current mr-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-                    <path d="M16 10c0 .553-.048 1-.601 1H11v4.399c0 .552-.447.601-1 .601-.553 0-1-.049-1-.601V11H4.601C4.049 11 4 10.553 4 10c0-.553.049-1 .601-1H9V4.601C9 4.048 9.447 4 10 4c.553 0 1 .048 1 .601V9h4.399c.553 0 .601.447.601 1z"/>
-                </svg>
-                {{ __('treatments.add_a_treatment') }}
-            </a>
         </div>
-
-
-        <div class="w-full">
-            <div class="w-1/3">
-                <a href="{{ route('dashboard') }}" class="button-link">{{ __('return_to_dashboard') }}</a>
-            </div>
-        </div>
-    </div>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
# What this does

Adds a question the first time you hit medications or treatments so the medical professional can indicate that there are no medications or treatments, and still submit the form.

Also fixed the validation for the dashboard - there was a case where if you added medications/treatments, then removed them so that the empty array still existed on the medicalReport, the validation would return true.

## To test
- On a new session, navigate to the Dashboard
- Notice medications/treatments are marked as not completed
- Navigate to either the medications or treatments section
- You will be asked to indicate if you will be entering medications or treatments
- If you select No and navigate back to the dashboard, the section should be marked completed
- If you select Yes, you will be directed to the form to create the first medication/treatment
- If you go straight back to the Dashboard without filling in the form, the section will be marked not complete
- If you then add a treatment/medication then navigate back to the dashboard, the section should be marked complete
- If you go back to the medications/treatments index and delete all items, then go back to the dashboard, the section should show as incomplete again.