### PR TITLE
Conditions: Explain why and provide more questions always appear, not required

### DIFF
--- a/api/schemas/condition.schema.js
+++ b/api/schemas/condition.schema.js
@@ -28,17 +28,6 @@ module.exports = {
       message: '^errors.condition_outlook_required'
     }
   },
-  conditionOutlookUnknown: function (value, attributes) {
-    const conditionOutlook = attributes.conditionOutlook;
-    if (conditionOutlook && conditionOutlook === '4') {
-      return {
-        presence: {
-          allowEmpty: false,
-          message: '^errors.condition_outlook_unknown'
-        }
-      };
-    }
-  },
   conditionLast: {
     presence: {
       message: '^errors.condition_last_required'
@@ -50,15 +39,4 @@ module.exports = {
       message: '^errors.symptoms_occur_required'
     }
   },
-  symptomsOccurUnknown: function (value, attributes) {
-    const symptomsOccur = attributes.symptomsOccur;
-    if (symptomsOccur && symptomsOccur === '3') {
-      return {
-        presence: {
-          allowEmpty: false,
-          message: '^errors.symptoms_occur_unknown_required'
-        }
-      };
-    }
-  }
 };

--- a/assets/js/pages/condition.js
+++ b/assets/js/pages/condition.js
@@ -1,4 +1,0 @@
-const checkUnknowns = require('./checkUnknowns');
-
-checkUnknowns('unknown_outlook_details', 'conditionOutlook', '4');
-checkUnknowns('unknown_symptoms_occur_details', 'symptomsOccur', '3');

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -43,7 +43,6 @@ module.exports.webpack = {
       entry: {
         app: './assets/js/app.js',
         styles: './assets/styles/app.scss',
-        condition: './assets/js/pages/condition.js',
         relationship: './assets/js/pages/relationship.js',
         conditionAdder: './assets/js/pages/conditionAdder.js',
         work: './assets/js/pages/work.js',

--- a/views/pages/conditions/add.njk
+++ b/views/pages/conditions/add.njk
@@ -1,9 +1,5 @@
 {% extends "layouts/layout.njk" %}
 
-{% block scripts %}
-    <script type="text/javascript" src="/build/assets/js/condition.js"></script>
-{% endblock %}
-
 {% block content %}
     {%- from 'pages/conditions/condition-form.njk' import conditionForm with context -%}
     

--- a/views/pages/conditions/add_first.njk
+++ b/views/pages/conditions/add_first.njk
@@ -1,9 +1,5 @@
 {% extends "layouts/layout.njk" %}
 
-{% block scripts %}
-    <script type="text/javascript" src="/build/assets/js/condition.js"></script>
-{% endblock %}
-
 {% block content %}
     {%- from 'pages/conditions/condition-form.njk' import conditionForm with context -%}
     {%- from 'pages/conditions/condition-name.njk' import conditionName with context -%}

--- a/views/pages/conditions/condition-form.njk
+++ b/views/pages/conditions/condition-form.njk
@@ -7,15 +7,12 @@
 
     {{ radioButtons('conditionOutlook', { '1':'add_condition.condition_outlook_improve','2':'add_condition.condition_outlook_deteriorate', '3':'add_condition.condition_outlook_staysame', '4':'add_condition.condition_outlook_unknown'}, condition.conditionOutlook, 'add_condition.condition_outlook', errors, { required: true }) }}
 
-    <div id="unknown_outlook_details" class="ml-4">
-        {{ textArea('conditionOutlookUnknown', 'add_condition.prognosis_unknown', { required: true, value: condition.conditionOutlookUnknown }) }}
-    </div>
+    {{ textArea('conditionOutlookUnknown', 'add_condition.prognosis_unknown', { value: condition.conditionOutlookUnknown }) }}
 
     {{ radioButtons('conditionLast', { '1':'add_condition.condition_last_1_year', '2':'add_condition.condition_last_more' }, condition.conditionLast, 'add_condition.condition_last', errors, { required: true }) }}
 
     {{ radioButtons('symptomsOccur', { '1':'add_condition.symptoms_occur_periodically', '2':'add_condition.symptoms_occur_continuously', '3':'add_condition.symptoms_occur_unknown'}, condition.symptomsOccur, 'add_condition.symptoms_occur', errors, { required: true }) }}
 
-    <div id="unknown_symptoms_occur_details" class="ml-4">
-        {{ textArea('symptomsOccurUnknown', 'add_condition.symptoms_occur_unknown_label', { required: true, value: condition.symptomsOccurUnknown }) }}
-    </div>
+    {{ textArea('symptomsOccurUnknown', 'add_condition.symptoms_occur_unknown_label', { value: condition.symptomsOccurUnknown }) }}
+
 {% endmacro %}

--- a/views/pages/conditions/edit.njk
+++ b/views/pages/conditions/edit.njk
@@ -1,9 +1,5 @@
 {% extends "layouts/layout.njk" %}
 
-{% block scripts %}
-    <script type="text/javascript" src="/build/assets/js/condition.js"></script>
-{% endblock %}
-
 {% block content %}
     {%- from 'pages/conditions/condition-form.njk' import conditionForm with context -%}
     


### PR DESCRIPTION
# Description 

https://trello.com/c/22XV8uYQ/549-explain-why-this-is-the-case-on-prognosis-and-frequency-should-always-appear-not-only-just-when-the-hcp-clicks-no

# Test

1. Launch app
1. Fill out personal, consent forms to get an invite code
1. Login with invite code
1. Add a medical condition, see if fields show
1. Add a second medical condition, see if fields show
1. Edit a medical condition, see if fields show