### PR TITLE
Adding a feature flag to disable validation

### DIFF
--- a/api/controllers/AddConditionController.js
+++ b/api/controllers/AddConditionController.js
@@ -36,8 +36,13 @@ module.exports = {
     // delete stuff we don't want to save
     delete body._csrf;
     delete body.save_and;
+    let valid = false;
 
-    let valid = req.validate(req, res, require('../schemas/condition.schema'));
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/condition.schema'));
+    }
 
     if (valid) {
       // save model here

--- a/api/controllers/AddMedicationController.js
+++ b/api/controllers/AddMedicationController.js
@@ -40,7 +40,13 @@ module.exports = {
       req.body = ConditionHelper.addConditions(req, body, 'medicationTreatedCondition');
     }
 
-    let valid = req.validate(req, res, require('../schemas/medication.schema'));
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/medication.schema'));
+    }
 
     if (valid) {
       // save model here

--- a/api/controllers/AddTreatmentController.js
+++ b/api/controllers/AddTreatmentController.js
@@ -40,7 +40,13 @@ module.exports = {
       req.body = ConditionHelper.addConditions(req, body, 'treatmentTreatedCondition');
     }
 
-    let valid = req.validate(req, res, require('../schemas/treatment.schema'));
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/treatment.schema'));
+    }
 
     if (valid) {
       // save model here

--- a/api/controllers/ConsentController.js
+++ b/api/controllers/ConsentController.js
@@ -25,7 +25,13 @@ module.exports = {
   },
 
   store: function (req, res) {
-    let valid = req.validate(req, res, require('../schemas/consent.schema'));
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/consent.schema'));
+    }
 
     if (valid) {
       // save the model

--- a/api/controllers/DashboardController.js
+++ b/api/controllers/DashboardController.js
@@ -36,15 +36,19 @@ function getSectionsCompleted(report) {
 }
 
 function ableToSubmit (sections) {
-  return sections.personal &&
-         sections.expedited &&
-         sections.functional &&
-         sections.conditions &&
-         sections.medications &&
-         sections.treatments &&
-         sections.futureWork &&
-         sections.supportingDocuments &&
-         sections.overallHealth;
+  if (require('../../config/featureflags').disableValidation) {
+    return true;
+  } else {
+    return sections.personal &&
+          sections.expedited &&
+          sections.functional &&
+          sections.conditions &&
+          sections.medications &&
+          sections.treatments &&
+          sections.futureWork &&
+          sections.supportingDocuments &&
+          sections.overallHealth;
+  }
 }
 
 function isValid(obj, schema) {

--- a/api/controllers/DeclarationController.js
+++ b/api/controllers/DeclarationController.js
@@ -25,7 +25,14 @@ module.exports = {
   },
 
   store: function (req, res) {
-    let valid = req.validate(req, res, require('../schemas/declaration.schema'));
+
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/declaration.schema'));
+    }
 
     if (valid) {
       // save the model

--- a/api/controllers/DocumentsController.js
+++ b/api/controllers/DocumentsController.js
@@ -28,7 +28,14 @@ module.exports = {
   },
 
   store: function (req, res) {
-    let valid = req.validate(req, res, require('../schemas/documents.schema'));
+
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/documents.schema'));
+    }
 
     if (valid) {
       // save the model

--- a/api/controllers/EditConditionController.js
+++ b/api/controllers/EditConditionController.js
@@ -46,7 +46,14 @@ module.exports = {
     // the conditions array is 0 indexed
     const conditionId = req.params.id - 1;
 
-    let valid = req.validate(req, res, require('../schemas/condition.schema'));
+
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/condition.schema'));
+    }
 
     if (valid) {
       // replace the contents of the condition on the array

--- a/api/controllers/EditMedicationController.js
+++ b/api/controllers/EditMedicationController.js
@@ -64,7 +64,14 @@ module.exports = {
     // the medications array is 0 indexed
     const medicationId = req.params.id - 1;
 
-    let valid = req.validate(req, res, require('../schemas/medication.schema'));
+
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/medication.schema'));
+    }
 
     if (valid) {
       // replace the contents of the medication on the array

--- a/api/controllers/EditTreatmentController.js
+++ b/api/controllers/EditTreatmentController.js
@@ -65,7 +65,14 @@ module.exports = {
     // the medications array is 0 indexed
     const treatmentId = req.params.id - 1;
 
-    let valid = req.validate(req, res, require('../schemas/treatment.schema'));
+
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/treatment.schema'));
+    }
 
     if (valid) {
       // replace the contents of the medication on the array

--- a/api/controllers/EmploymentController.js
+++ b/api/controllers/EmploymentController.js
@@ -25,7 +25,14 @@ module.exports = {
   },
 
   store: function (req, res) {
-    let valid = req.validate(req, res, require('../schemas/employment.schema'));
+
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/employment.schema'));
+    }
 
     if (valid) {
       // save the model

--- a/api/controllers/ExpeditedController.js
+++ b/api/controllers/ExpeditedController.js
@@ -25,7 +25,13 @@ module.exports = {
   },
 
   store: function (req, res) {
-    let valid = req.validate(req, res, require('../schemas/expedited.schema'));
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/expedited.schema'));
+    }
 
     if (valid) {
       // save the model

--- a/api/controllers/FunctionalController.js
+++ b/api/controllers/FunctionalController.js
@@ -22,7 +22,13 @@ module.exports = {
     });
   },
   store: function (req, res) {
-    let valid = req.validate(req, res, require('../schemas/functional.schema'));
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/functional.schema'));
+    }
 
     if (valid) {
       // save the model, but not yet to the datastore

--- a/api/controllers/FutureWorkCapacityController.js
+++ b/api/controllers/FutureWorkCapacityController.js
@@ -25,7 +25,14 @@ module.exports = {
   },
 
   store: function (req, res) {
-    let valid = req.validate(req, res, require('../schemas/work.schema'));
+
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/work.schema'));
+    }
 
     if (valid) {
       // save the model

--- a/api/controllers/HealthController.js
+++ b/api/controllers/HealthController.js
@@ -25,7 +25,14 @@ module.exports = {
   },
 
   store: function (req, res) {
-    let valid = req.validate(req, res, require('../schemas/health.schema'));
+
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/health.schema'));
+    }
 
     if (valid) {
       // save the model

--- a/api/controllers/MedicationsController.js
+++ b/api/controllers/MedicationsController.js
@@ -15,14 +15,21 @@ module.exports = {
   },
 
   save: function (req, res) {
-    let valid = req.validate(req, res, {
-      patientMedications: {
-        presence: {
-          allowEmpty: false,
-          message: '^Please make a selection'
-        }
-      },
-    });
+
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, {
+        patientMedications: {
+          presence: {
+            allowEmpty: false,
+            message: '^Please make a selection'
+          }
+        },
+      });
+    }
 
     if (valid) {
       // save the model

--- a/api/controllers/RelationshipController.js
+++ b/api/controllers/RelationshipController.js
@@ -25,7 +25,14 @@ module.exports = {
   },
 
   store: function (req, res) {
-    let valid = req.validate(req, res, require('../schemas/relationship.schema'));
+
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, require('../schemas/relationship.schema'));
+    }
 
     if (valid) {
       // save the model

--- a/api/controllers/TreatmentsController.js
+++ b/api/controllers/TreatmentsController.js
@@ -15,14 +15,21 @@ module.exports = {
   },
 
   save: function (req, res) {
-    let valid = req.validate(req, res, {
-      patientTreatments: {
-        presence: {
-          allowEmpty: false,
-          message: '^Please make a selection'
-        }
-      },
-    });
+
+    let valid = false;
+
+    if (require('../../config/featureflags').disableValidation) {
+      valid = true;
+    } else {
+      valid = req.validate(req, res, {
+        patientTreatments: {
+          presence: {
+            allowEmpty: false,
+            message: '^Please make a selection'
+          }
+        },
+      });
+    }
 
     if (valid) {
       // save the model

--- a/config/featureflags.js
+++ b/config/featureflags.js
@@ -1,0 +1,3 @@
+module.exports = {
+  disableValidation: true
+};


### PR DESCRIPTION
Add a compile time feature flag in `~/configs/featureFlags.js` that disables validation on all pages that aren't tied to consent. 

Also allows the end user to submit from the dashboard at any time. 