### PR TITLE
Medications conditions name

### DIFF
--- a/api/controllers/AddMedicationController.js
+++ b/api/controllers/AddMedicationController.js
@@ -77,9 +77,9 @@ module.exports = {
       /**
        * Associate the selected existing conditions
        */
-      if (req.body.selectedConditions) {
+      if (req.body.Conditions) {
         // It won't be an array if only one checkbox is checked
-        let selectedConditions = arrayHelpers.castArray(req.body.selectedConditions);
+        let selectedConditions = arrayHelpers.castArray(req.body.Conditions);
 
         selectedConditions.forEach(async (conditionId) => {
           // Get an instance of the condition

--- a/api/controllers/EditMedicationController.js
+++ b/api/controllers/EditMedicationController.js
@@ -62,7 +62,7 @@ module.exports = {
      * Get an array of selected ids, assign it back to the
      * medication object for convenience.
      */
-    medication.selectedConditions = arrayHelpers.pluckIds(medication.Conditions);
+    _.set(res.locals, 'data.selectedConditions', arrayHelpers.pluckIds(medication.Conditions));
 
     /**
      * If we're returning to the form with flash data in locals,
@@ -143,9 +143,9 @@ module.exports = {
       /**
        * Associate the selected existing conditions
        */
-      if (req.body.selectedConditions) {
+      if (req.body.Conditions) {
         // It won't be an array if only one checkbox is checked
-        let selectedConditions = arrayHelpers.castArray(req.body.selectedConditions);
+        let selectedConditions = arrayHelpers.castArray(req.body.Conditions);
 
         selectedConditions.forEach(async (conditionId) => {
           // Get an instance of the condition

--- a/api/schemas/medication.schema.js
+++ b/api/schemas/medication.schema.js
@@ -23,7 +23,7 @@ module.exports = {
       allowEmpty: false,
     },
   },
-  selectedConditions: function (value, attributes) {
+  Conditions: function (value, attributes) {
     /**
      * This should also be valid if we've added new conditions,
      * but we'll need to clear out any empty conditions from

--- a/views/pages/medications/medication-form.njk
+++ b/views/pages/medications/medication-form.njk
@@ -27,7 +27,7 @@
     { required: true, hint: 'form.medication_results.hint', value: medication.medicationResults, class: 'w-full' }
 ) }}
 
-{{ rawCheckBoxes('selectedConditions', 
+{{ rawCheckBoxes('Conditions', 
     conditionList,
     medication.selectedConditions, 
     'form.medication_treated_conditions.question',{},


### PR DESCRIPTION
Renaming the selectedConditions checkbox array to Conditions for consistency with the relationship alias - makes validation easier. (made same change to the Treatments PR)