### PR TITLE
Medical Adjudicator Session View and Report View for Database Integration Branch

### DIFF
--- a/api/controllers/SessionsController.js
+++ b/api/controllers/SessionsController.js
@@ -31,14 +31,28 @@ module.exports = {
   },
 
   view: async function (req, res) {
+    const reportId = req.params.session;
+    sails.log.silly(`Requesing medical report: ${reportId}`);
+    const medicalReport = await MedicalReport.findOne({
+      where: {id: reportId},
+      include: [{
+        model: Condition,
+        as: 'Conditions',
+        include: [ {
+          model: Treatment,
+          as: 'Treatments'
+        }, {
+          model: Medication,
+          as: 'Medications'
+        }
+        ]
 
-    const medicalReport = await MedicalReport.findOne({ where: {id: req.params.session}});
+      }]
+    });
     sails.log.silly(`medicalReport: ${JSON.stringify(medicalReport.toJSON(), null, 2)}`);
 
-    const conditions = conditionHelper.getConditionsWithMedicationsAndTreatments(medicalReport);
     res.view('pages/sessions/view', {
       data:medicalReport,
-      conditions: conditions,
       symptomsOccur: require('../utils/support/symptomsOccur'),
       conditionOutlook: require('../utils/support/conditionOutlook'),
       stopWorking: require('../utils/support/stopWorking'),

--- a/api/controllers/SessionsController.js
+++ b/api/controllers/SessionsController.js
@@ -11,11 +11,11 @@ module.exports = {
   index: async function (req, res) {
 
     const reports = await MedicalReport.findAll({limit: 10, attributes: ['id', 'firstName', 'lastName', 'socialInsuranceNumber']});
-    sails.log(`Query returned: ${JSON.stringify(reports)}`);
+    sails.log.silly(`Query returned: ${JSON.stringify(reports, null,  2)}`);
     const viewModel = reports.map(x =>  {
       return {
         id: x.id,
-        dateRecieved: 'Not Implemented',
+        dateReceived: 'Not Implemented',
         applicant: `${x.lastName}, ${x.firstName}`,
         sin: x.socialInsuranceNumber,
         lastViewed: 'Not Implemented'
@@ -23,7 +23,7 @@ module.exports = {
     });
 
     const totalReports = await MedicalReport.count();
-    sails.log(`totalReports: ${totalReports}`);
+    sails.log.silly(`totalReports: ${totalReports}`);
     return res.view('pages/sessions', {
       reports: viewModel,
       total: totalReports
@@ -33,7 +33,7 @@ module.exports = {
   view: async function (req, res) {
 
     const medicalReport = await MedicalReport.findOne({ where: {id: req.params.session}});
-    sails.log(`medicalReport: ${JSON.stringify(medicalReport, 2)}`);
+    sails.log.silly(`medicalReport: ${JSON.stringify(medicalReport.toJSON(), null, 2)}`);
 
     const conditions = conditionHelper.getConditionsWithMedicationsAndTreatments(medicalReport);
     res.view('pages/sessions/view', {

--- a/api/controllers/SessionsController.js
+++ b/api/controllers/SessionsController.js
@@ -5,7 +5,6 @@
  * @help        :: See https://sailsjs.com/docs/concepts/actions
  */
 
-const path = require('path');
 const conditionHelper = require('../utils/ConditionHelpers');
 
 module.exports = {

--- a/api/controllers/SessionsController.js
+++ b/api/controllers/SessionsController.js
@@ -5,14 +5,12 @@
  * @help        :: See https://sailsjs.com/docs/concepts/actions
  */
 
-const conditionHelper = require('../utils/ConditionHelpers');
-
 module.exports = {
   index: async function (req, res) {
 
-    const reports = await MedicalReport.findAll({limit: 10, attributes: ['id', 'firstName', 'lastName', 'socialInsuranceNumber']});
-    sails.log.silly(`Query returned: ${JSON.stringify(reports, null,  2)}`);
-    const viewModel = reports.map(x =>  {
+    const reports = await MedicalReport.findAll({ limit: 10, attributes: ['id', 'firstName', 'lastName', 'socialInsuranceNumber'] });
+    sails.log.silly(`Query returned: ${JSON.stringify(reports, null, 2)}`);
+    const viewModel = reports.map(x => {
       return {
         id: x.id,
         dateReceived: 'Not Implemented',
@@ -34,17 +32,17 @@ module.exports = {
     const reportId = req.params.session;
     sails.log.silly(`Requesing medical report: ${reportId}`);
     const medicalReport = await MedicalReport.findOne({
-      where: {id: reportId},
+      where: { id: reportId },
       include: [{
         model: Condition,
         as: 'Conditions',
-        include: [ {
+        include: [{
           model: Treatment,
           as: 'Treatments'
         }, {
           model: Medication,
           as: 'Medications'
-        },{
+        }, {
           model: Document,
           as: 'Documents'
         }]
@@ -54,7 +52,7 @@ module.exports = {
     sails.log.silly(`medicalReport: ${JSON.stringify(medicalReport.toJSON(), null, 2)}`);
 
     res.view('pages/sessions/view', {
-      data:medicalReport,
+      data: medicalReport,
       symptomsOccur: require('../utils/support/symptomsOccur'),
       conditionOutlook: require('../utils/support/conditionOutlook'),
       stopWorking: require('../utils/support/stopWorking'),

--- a/api/controllers/SessionsController.js
+++ b/api/controllers/SessionsController.js
@@ -12,15 +12,16 @@ const conditionHelper = require('../utils/ConditionHelpers');
 module.exports = {
   index: function (req, res) {
 
-    let directory = path.resolve(__dirname, '../../sessions');
+    const reports = MedicalReport.findAll({limit: 10});
+    sails.log(`Found Items ${JSON.stringify(reports)}`);
 
-    fs.readdir(directory, (err, files) => {
-      if (!err) {
-        _.pull(files, '.gitignore');
-        res.view('pages/sessions', {
-          files: files
-        });
-      }
+    return res.view('pages/sessions', {
+      reports:[
+        { dateRecieved: '0001-01-01', applicant: 'John Doe', sin: '111 111 118', lastViewed: 'Now'},
+        { dateRecieved: '2001-01-01', applicant: 'Jane Doe', sin: '111 111 118', lastViewed: 'Now'},
+        { dateRecieved: '1999-01-01', applicant: 'Pierre Poutine', sin: '111 111 118', lastViewed: '0001-01-01'}
+      ],
+      total: 100
     });
   },
 
@@ -43,6 +44,7 @@ module.exports = {
   },
 
   view: function (req, res) {
+
     const filename = req.params.session;
     const sessionFile = path.resolve(__dirname, '../../sessions/' + filename);
 

--- a/api/controllers/SessionsController.js
+++ b/api/controllers/SessionsController.js
@@ -31,24 +31,6 @@ module.exports = {
     });
   },
 
-  download: function (req, res) {
-    const filename = req.params.session;
-    const sessionFile = path.resolve(__dirname, '../../sessions/' + filename);
-
-    var SkipperDisk = require('skipper-disk');
-    var fileAdapter = SkipperDisk(/* optional opts */);
-
-    // set the filename to the same file as the user uploaded
-    res.set('Content-disposition', 'attachment; filename=' + filename);
-
-    // Stream the file down
-    fileAdapter.read(sessionFile)
-      .on('error', (err) => {
-        return res.serverError(err);
-      })
-      .pipe(res);
-  },
-
   view: async function (req, res) {
 
     const medicalReport = await MedicalReport.findOne({ where: {id: req.params.session}});

--- a/api/controllers/SessionsController.js
+++ b/api/controllers/SessionsController.js
@@ -5,7 +5,6 @@
  * @help        :: See https://sailsjs.com/docs/concepts/actions
  */
 
-const fs = require('fs');
 const path = require('path');
 const conditionHelper = require('../utils/ConditionHelpers');
 
@@ -56,7 +55,6 @@ module.exports = {
     sails.log(`medicalReport: ${JSON.stringify(medicalReport, 2)}`);
 
     const conditions = conditionHelper.getConditionsWithMedicationsAndTreatments(medicalReport);
-    // console.log(require('../utils/support/symptomsOccur')[1]);
     res.view('pages/sessions/view', {
       data:medicalReport,
       conditions: conditions,

--- a/api/controllers/SessionsController.js
+++ b/api/controllers/SessionsController.js
@@ -44,8 +44,10 @@ module.exports = {
         }, {
           model: Medication,
           as: 'Medications'
-        }
-        ]
+        },{
+          model: Document,
+          as: 'Documents'
+        }]
 
       }]
     });
@@ -58,7 +60,6 @@ module.exports = {
       stopWorking: require('../utils/support/stopWorking'),
       returnToWorkWhen: require('../utils/support/returnToWorkWhen'),
       typeOfWork: require('../utils/support/typeOfWork'),
-      getDocumentsByCondition: require('../utils/DocumentsHelper').getDocumentsByCondition,
       moment: require('moment')
     });
   }

--- a/config/routes/sessions.js
+++ b/config/routes/sessions.js
@@ -13,17 +13,6 @@ module.exports.routes = {
     }
   },
 
-  'GET /en/sessions/:session/download': {
-    name: 'sessions.download',
-    controller: 'SessionsController',
-    action: 'download',
-    lang: 'en',
-    i18n: {
-      en: '/en/sessions/:session/download',
-      fr: '/fr/sessions/:session/download'
-    }
-  },
-
   'GET /en/sessions/:session/view': {
     name: 'sessions.view',
     controller: 'SessionsController',

--- a/views/pages/sessions.njk
+++ b/views/pages/sessions.njk
@@ -5,7 +5,7 @@
   <form class="w-full max-w-full">
     <div >
       <div class="relative">
-        <label for="search" class="sr-only">{{__("sessions.searchApplications")}}</label>
+        <label for="search" class="sr-only">{{ __("sessions.searchApplications") }}</label>
         <input id="search" class="placeholder-gray-600 rounded-lg  pl-10 block w-full appearance-none leading-normal mb-10" type="text" placeholder="{{__("sessions.searchApplications")}}">
         <div class="pointer-events-none absolute inset-y-0 left-0 pl-4 flex items-center">
           <svg class="fill-current pointer-events-none text-gray-600 w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42 1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12z"/></svg>
@@ -13,21 +13,21 @@
       </div>
     </div>
   </form>
-  <table class="w-full">
+  <table class="w-full table-full">
     <thead class="border-solid border-b-2 text-left">
-      <tr class="flex" >
+      <tr  >
         <th class="w-1/4">Date Recieved</th>
         <th class="w-2/4">Applicant</th>
         <th class="w-1/4">Last opened</th>
       </tr>
     </thead>
-    <tbody class="" >
+    <tbody >
       {% set zebra = cycler("", "bg-gray-200") %}
       {% for report in reports %}
-        <tr class="flex p-2 {{zebra.next()}}">
-          <td class="w-1/4 ">{{ report.dateRecieved}}</td>
-          <td class="w-2/4 "><a href={{ route('sessions.view', { session: report.id})}}>{{ report.applicant}}</a> ({{report.sin }})</td>
-          <td class="w-1/4 ">{{ report.lastViewed}}</td>
+        <tr class=" {{ zebra.next() }}">
+          <td class="w-1/4 py-2">{{ report.dateReceived }}</td>
+          <td class="w-2/4 py-2"><a href={{ route('sessions.view', { session: report.id }) }}>{{ report.applicant }}</a> ({{ report.sin }})</td>
+          <td class="w-1/4 py-2">{{ report.lastViewed }}</td>
         </tr>
       {% endfor %}
     </tbody>
@@ -37,7 +37,7 @@
     {% set pages = ((total/8)|round(0,'ceil')) %}
     {% if total > 8 %}
       {% for i in range(0, pages) %}
-        <a href="about/blank" class="m-1"><span class="sr-only">Navigate to page </span>{{ i + 1 }}<span class="sr-only"> of {{ pages }}</span></a>
+        <a href="#" class="m-1"><span class="sr-only">Page </span>{{ i + 1 }}<span class="sr-only"> of {{ pages }}</span></a>
       {% endfor %}
     {% endif %}
   </div>

--- a/views/pages/sessions.njk
+++ b/views/pages/sessions.njk
@@ -2,11 +2,42 @@
 
 {% block content %}
   <h1>Sessions</h1>
+  <form class="w-full max-w-full">
+    <div >
+      <div class="relative">
+        <label for="search" class="sr-only">{{__("sessions.searchApplications")}}</label>
+        <input id="search" class="placeholder-gray-600 rounded-lg  pl-10 block w-full appearance-none leading-normal mb-10" type="text" placeholder="{{__("sessions.searchApplications")}}">
+        <div class="pointer-events-none absolute inset-y-0 left-0 pl-4 flex items-center">
+          <svg class="fill-current pointer-events-none text-gray-600 w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42 1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12z"/></svg>
+        </div>
+      </div>
+    </div>
+  </form>
+  <table class="w-full">
+    <thead class="border-solid border-b-2 text-left">
+      <tr class="flex" >
+        <th class="w-1/4">Date Recieved</th>
+        <th class="w-2/4">Applicant</th>
+        <th class="w-1/4">Last opened</th>
+      </tr>
+    </thead>
+    <tbody >
+      {% for report in reports %}
+        <tr class="flex p-2 {{ 'bg-gray-200' if loop.index % 2 == 0  }}">
+          <td class="w-1/4 ">{{ report.dateRecieved}}</td>
+          <td class="w-2/4 "><a href="about/blank">{{ report.applicant}}</a> ({{report.sin }})</td>
+          <td class="w-1/4 ">{{ report.lastViewed}}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
 
-  <ul>
-    {% for file in files %}
-      <li>{{ file }} <a href="{{ route('sessions.download', { session: file }) }}">Download</a> | <a href="{{ route('sessions.view', { session: file }) }}">View</a></li>
-    {% endfor %}
-  </ul>
-
+  <div class="my-4">
+    {% set pages = ((total/8)|round(0,'ceil')) %}
+    {% if total > 8 %}
+      {% for i in range(0, pages) %}
+        <a href="about/blank" class="m-1"><span class="sr-only">Navigate to page </span>{{ i + 1 }}<span class="sr-only"> of {{ pages }}</span></a>
+      {% endfor %}
+    {% endif %}
+  </div>
 {% endblock %}

--- a/views/pages/sessions.njk
+++ b/views/pages/sessions.njk
@@ -25,7 +25,7 @@
       {% for report in reports %}
         <tr class="flex p-2 {{ 'bg-gray-200' if loop.index % 2 == 0  }}">
           <td class="w-1/4 ">{{ report.dateRecieved}}</td>
-          <td class="w-2/4 "><a href="about/blank">{{ report.applicant}}</a> ({{report.sin }})</td>
+          <td class="w-2/4 "><a href={{ route('sessions.view', { session: report.id})}}>{{ report.applicant}}</a> ({{report.sin }})</td>
           <td class="w-1/4 ">{{ report.lastViewed}}</td>
         </tr>
       {% endfor %}

--- a/views/pages/sessions.njk
+++ b/views/pages/sessions.njk
@@ -21,9 +21,10 @@
         <th class="w-1/4">Last opened</th>
       </tr>
     </thead>
-    <tbody >
+    <tbody class="" >
+      {% set zebra = cycler("", "bg-gray-200") %}
       {% for report in reports %}
-        <tr class="flex p-2 {{ 'bg-gray-200' if loop.index % 2 == 0  }}">
+        <tr class="flex p-2 {{zebra.next()}}">
           <td class="w-1/4 ">{{ report.dateRecieved}}</td>
           <td class="w-2/4 "><a href={{ route('sessions.view', { session: report.id})}}>{{ report.applicant}}</a> ({{report.sin }})</td>
           <td class="w-1/4 ">{{ report.lastViewed}}</td>

--- a/views/pages/sessions/view.njk
+++ b/views/pages/sessions/view.njk
@@ -76,16 +76,16 @@
 
       <dt>{{ __('ma.view.label.supporting_documents') }}</dt>
       <dd>
-        {% for document in getDocumentsByCondition(data, loop.index0) %}
-          {{ document }}<br>
+        {% for document in condition.Documents %}
+          {{ document.fileName }}<br>
         {% endfor %}
       </dd>
     </dl>
 
-    {% if condition.medications.length %}
+    {% if condition.Medications.length %}
       <details>
         <summary><h4 class="mt-4 text-2xl inline">Medications</h4></summary>
-        {% for medication in condition.medications %}
+        {% for medication in condition.Medications %}
           <dl>
               <dt>{{ __('ma.view.label.medication') }}</dt>
               <dd>{{ medication.medicationName }}</dd>
@@ -109,10 +109,10 @@
       </details>
     {% endif %}
 
-    {% if condition.treatments.length %}
+    {% if condition.Treatments.length %}
       <details>
         <summary><h4 class="mt-4 text-2xl inline">Treatments</h4></summary>
-        {% for treatment in condition.treatments %}
+        {% for treatment in condition.Treatments %}
           <dl>
             <dt>{{ __('ma.view.label.treatment_type') }}</dt>
             <dd>{{ treatment.treatmentType }}</dd>

--- a/views/pages/sessions/view.njk
+++ b/views/pages/sessions/view.njk
@@ -18,7 +18,6 @@
     {{ __('ma.view.label.phone') }} {{ data.telephone }}<br>
   </p>
 </details>
-
 <details class="mt-4" open>
   <summary><h2 class="mt-4 text-4xl inline">{{ __('ma.view.relationship_with_applicant') }}</h2></summary>
   <dl>
@@ -56,22 +55,22 @@
     <dl>
       <dt>{{ __('ma.view.label.icd_code') }}</dt>
       <dd>{{ condition.icdCode }}</dd>
-    
+
       <dt>{{ __('ma.view.label.symptoms_began') }}</dt>
       <dd>{{ condition.symptomsBegan }}</dd>
-    
+
       <dt>{{ __('ma.view.label.symptom_frequency') }}</dt>
       <dd>{{ __(symptomsOccur[condition.symptomsOccur]) }}</dd>
-    
+
       <dt>{{ __('ma.view.label.symptom_detail') }}</dt>
       <dd>{{ condition.symptomsOccurUnknown }}</dd>
-    
+
       <dt>{{ __('ma.view.label.prognosis') }}</dt>
       <dd>{{ __(conditionOutlook[condition.conditionOutlook]) }}</dd>
-    
+
       <dt>{{ __('ma.view.label.prognosis_detail') }}</dt>
       <dd>{{ condition.conditionOutlookUnknown }}</dd>
-    
+
       <dt>{{ __('ma.view.label.clinical_findings') }}</dt>
       <dd>{{ condition.clinicallyImpair }}</dd>
 
@@ -82,7 +81,7 @@
         {% endfor %}
       </dd>
     </dl>
-    
+
     {% if condition.medications.length %}
       <details>
         <summary><h4 class="mt-4 text-2xl inline">Medications</h4></summary>
@@ -90,26 +89,26 @@
           <dl>
               <dt>{{ __('ma.view.label.medication') }}</dt>
               <dd>{{ medication.medicationName }}</dd>
-            
+
               <dt>{{ __('ma.view.label.start_date') }}</dt>
               <dd>{{ medication.medicationStartDate }}</dd>
-            
+
               <dt>{{ __('ma.view.label.end_date') }}</dt>
               <dd>{{ medication.medicationEndDate }}</dd>
-            
+
               <dt>{{ __('ma.view.label.dosage') }}</dt>
               <dd>{{ medication.medicationDosage }}</dd>
-            
+
               <dt>{{ __('ma.view.label.frequency') }}</dt>
               <dd>{{ medication.medicationFrequency }}</dd>
-            
+
               <dt>{{ __('ma.view.label.patient_response') }}</dt>
               <dd>{{ medication.medicationResults }}</dd>
           </dl>
         {% endfor %}
       </details>
     {% endif %}
-    
+
     {% if condition.treatments.length %}
       <details>
         <summary><h4 class="mt-4 text-2xl inline">Treatments</h4></summary>
@@ -136,17 +135,17 @@
   </details>
 {% endfor %}
 
-<details class="mt-4" open>
+ <details class="mt-4" open>
   <summary><h2 class="mt-4 text-4xl inline">{{ __('ma.view.work_capacity') }}</h2></summary>
   <dl>
     <dt>{{ __('ma.view.label.told_to_cease_work') }}</td>
-    <dd>{{ __(stopWorking[data.stopWorking]) }}
+    <dd>{{ __(stopWorking[data.stopWorking]) if data.stopWorking }}
 
     <dt>{{ __('ma.view.label.expected_to_return_to_work') }}
-    <dd>{{ __(returnToWorkWhen[data.returnToWorkWhen]) }}
+    <dd>{{ __(returnToWorkWhen[data.returnToWorkWhen] if data.returnToWorkWhen) }}
 
     <dt>{{ __('ma.view.label.type_of_work') }}</dt>
-    <dd>{{ __(typeOfWork[data.typeOfWork]) }}</dd>
+    <dd>{{ __(typeOfWork[data.typeOfWork]) if data.typeOfWork }}</dd>
 
     <dt>{{ __('ma.view.label.type_of_work_detail') }}</dt>
     <dd>{{ data.workDetails }}

--- a/views/pages/sessions/view.njk
+++ b/views/pages/sessions/view.njk
@@ -49,7 +49,7 @@
   <dd>26.8</dd>
 </dl>
 
-{% for condition in conditions %}
+{% for condition in data.Conditions %}
   <details class="mt-4" open>
     <summary><h3 class="mt-4 inline">{{ condition.conditionName }}</h3></summary>
     <dl>


### PR DESCRIPTION
## To Test

Enter in a medical report. 
Navigate to /en/sessions to view the medical reports in the database 
Click on the Name of an Applicant to view their medical report


## Please note:
This is for the Trello Card: [Data is Saved to a Database](https://trello.com/c/Du6NkXXg/487-data-is-saved-to-a-database) and not the [MA View card](https://trello.com/c/UR2P2T1H/350-mas-can-view-what-applications-are-received-so-that-they-can-adjudicate-claims )
Although it does implement some of the styling of that card. For the sake of a smaller PR I've decided to do these in two seperate chunks

## Not Implemented
 - Search 
 - Proper Pagination
 - Empty sections are still displayed on MA View 
 - Filtering to display only submitted Reports
