### PR TITLE
Decouple localization strings from *some* macros.

### DIFF
--- a/views/layouts/layout.njk
+++ b/views/layouts/layout.njk
@@ -4,6 +4,7 @@
 {%- from 'macros/input-textarea.njk' import textArea as textArea with context -%}
 {%- from 'macros/input-textarea-raw.njk' import textAreaRaw as textAreaRaw with context -%}
 {%- from 'macros/radios.njk' import radioButtons as radioButtons with context -%}
+{%- from 'macros/radios-raw.njk' import radioButtonsRaw as radioButtonsRaw with context -%}
 {%- from 'macros/checkboxes.njk' import checkBoxes as checkBoxes with context -%}
 {%- from 'macros/buttons.njk' import formButtons as formButtons with context -%}
 {%- from 'macros/input-file.njk' import fileInput as fileInput with context -%}

--- a/views/macros/radios-raw.njk
+++ b/views/macros/radios-raw.njk
@@ -1,0 +1,29 @@
+{% macro radioButtonsRaw(key, values, value, question, errors, attributes) %}
+    <div class="{{ 'has-error' if errors and errors[key] }}">
+        <fieldset class="fieldset">
+            <legend class="fieldset__legend">
+            {% if attributes.required %}
+                <span aria-hidden="true" class="required">*</span>
+            {% endif %}
+            {{ question }}
+            {% if attributes.required %}
+                <span class="required">{{ __("required")}}</span>
+            {% endif %}
+            </legend>
+            {% if attributes.hint %}
+                <span class="form-message">{{ __(attributes.hint) }}</span>
+            {% endif %}
+            <div class="multiple-choice multiple-choice--radios" id="{{ key }}">
+                {% if errors and errors[key] %}
+                    {{ validationMessage(errors[key], key) }}
+                {% endif %}
+                {% for index, val in values %}
+                    <div class="multiple-choice__item">
+                        <input id="{{ key }}{{ val }}" name="{{ key }}" type="radio" value="{{ index }}" {% if value == index %} checked="checked" {% endif %} {% if errors and errors[key] %} aria-describedby="{{ key + '-error' }}" aria-invalid="true" {% endif %}>
+                        <label for="{{ key }}{{ val }}">{{ __(val) }}</label>
+                    </div>
+                {% endfor %}
+            </div>
+        </fieldset>
+    </div>
+{% endmacro %}

--- a/views/pages/relationship.njk
+++ b/views/pages/relationship.njk
@@ -7,7 +7,7 @@
 {% block content %}
 
     {{ backButton('dashboard') }}
-    
+
     <h1>{{ __('section3.title') }}</h1>
 
     <div>
@@ -15,16 +15,16 @@
 
             <input type="hidden" name="_csrf" value="{{ _csrf }}">
 
-            {{ textInput('relationshipStarted', __('section3.form.relationship_started.desc', patientName(data)), { required: true, hint: 'For example: Feb 2008' }) }}
+            {{ textInputRaw('relationshipStarted', __('section3.form.relationship_started.desc', patientName(data)), { required: true, hint: 'For example: Feb 2008' }) }}
 
-            {{ textInput('firstTreatmentDate', __('section3.form.first_treatment_date.desc', patientName(data)), { hint: 'For example: Feb 3, 2016', required: true }) }}
+            {{ textInputRaw('firstTreatmentDate', __('section3.form.first_treatment_date.desc', patientName(data)), { hint: 'For example: Feb 3, 2016', required: true }) }}
 
-            {{ textInput('visitNumber', __('section3.form.visit_number.desc', patientName(data)), { required: true }) }}
+            {{ textInputRaw('visitNumber', __('section3.form.visit_number.desc', patientName(data)), { required: true }) }}
 
             {{ textInput('lastVisitDate', 'section3.form.last_visit_date.desc', { hint: 'For example: Nov 15, 2019', required: true }) }}
 
             {{
-                radioButtons('stopWorking',
+                radioButtonsRaw('stopWorking',
                     {
                         '1': 'Yes',
                         '2': 'No',

--- a/views/pages/work.njk
+++ b/views/pages/work.njk
@@ -14,7 +14,7 @@
             <input type="hidden" name="_csrf" value="{{ _csrf }}">
 
             {{
-                radioButtons('returnToWork',
+                radioButtonsRaw('returnToWork',
                     {
                         '1': 'Yes',
                         '2': 'No',
@@ -29,7 +29,7 @@
             <div id="additional_fields">
                 <div class="my-10">
                 {{
-                    radioButtons('returnToWorkWhen',
+                    radioButtonsRaw('returnToWorkWhen',
                         {
                             '1': 'section6.return_work_6_to_12_months',
                             '2': 'section6.return_work_12_to_24_months',
@@ -45,7 +45,7 @@
 
                 <div class="my-10">
                 {{
-                    radioButtons('typeOfWork',
+                    radioButtonsRaw('typeOfWork',
                         {
                             '1': 'section6.type_work_usual',
                             '2': 'section6.type_work_modified',


### PR DESCRIPTION
- Add a radio button macro that doesn't translate the question
- replace some `textBox` with `textBoxRaw`

** Please Note: ** We will eventually de-couple most internationalized
strings from macros. Items like the `required` should probably in macros
still