### PR TITLE
Clear session at start

### DIFF
--- a/api/controllers/StartController.js
+++ b/api/controllers/StartController.js
@@ -6,8 +6,13 @@
  */
 
 module.exports = {
-  index: function(req, res) {
-    req.session.medicalReport = {};
+  index: function (req, res) {
+    /**
+     * If there is an applicationCode in the session, clear it
+     */
+    if (req.session.applicationCode) {
+      req.session.applicationCode = null;
+    }
     res.view('pages/start');
   }
 };


### PR DESCRIPTION
# What this does

See: https://trello.com/c/UQyBilRv/637-clear-sessions-at-start-and-doctor-views

Resets the session at Start.

This was an oversight, the change had previously been made to the Doctor route, it was just missed here.
