### PR TITLE
Fix dashboard validation of Treatments and Medications

### DIFF
--- a/api/controllers/MedicationsController.js
+++ b/api/controllers/MedicationsController.js
@@ -42,7 +42,7 @@ module.exports = {
         }
       });
 
-      if (req.body.patientMedications) {
+      if (req.body.patientMedications === '1') {
         return res.redirect(sails.route('medications.add'));
       }
 

--- a/api/controllers/TreatmentsController.js
+++ b/api/controllers/TreatmentsController.js
@@ -42,7 +42,7 @@ module.exports = {
         }
       });
 
-      if (req.body.patientTreatments) {
+      if (req.body.patientTreatments === '1') {
         return res.redirect(sails.route('treatments.add'));
       }
 

--- a/api/utils/DashboardHelpers.js
+++ b/api/utils/DashboardHelpers.js
@@ -25,7 +25,7 @@ function checkMedications(medicalReport) {
 }
 
 function checkTreatements(medicalReport) {
-  if (!medicalReport.patientTreatments === false) {
+  if (medicalReport.patientTreatments === false) {
     return true;
   }
   return isCollectionValid(medicalReport.Treatments);

--- a/api/utils/DashboardHelpers.js
+++ b/api/utils/DashboardHelpers.js
@@ -18,14 +18,14 @@ const isCollectionValid = (models) => {
 }
 
 function checkMedications(medicalReport) {
-  if (!medicalReport.patientMedications) {
+  if (medicalReport.patientMedications === false) {
     return true;
   }
   return isCollectionValid(medicalReport.Medications);
 }
 
 function checkTreatements(medicalReport) {
-  if (!medicalReport.patientTreatments) {
+  if (!medicalReport.patientTreatments === false) {
     return true;
   }
   return isCollectionValid(medicalReport.Treatments);


### PR DESCRIPTION
# What this does

Fixes a small bug on the Dashboard validation of Treatments and Medications. Previously, the test would return true on `!medicalReport.patientMedications` and `!medicalReport.patientTreatments` - these fields are BOOLEAN types, but that check will return true on NULL values, which was not correct. Made the test more explicit.

There was also a similar issue in the TreatmentsController and MedicationsController - controlling the redirect after selecting whether the patient is receiving Treatments or Medications.

## To test
Create a new medicalReport, navigate to the dashboard, and the Treatments/Medications sections should be marked not complete. (Previously, they would have been showing as complete)

Also:
- Navigate to the Treatments section
- Select No and Submit
- You should be directed back to the Dashboard, and the section has been marked complete
- Navigate back to the Treatments section
- Select Yes and Submit
- You should be directed on to the Treatment form.

Repeat the above tests for the Medications section.