### PR TITLE
Handle uploading files

### DIFF
--- a/api/controllers/API/DocumentsController.js
+++ b/api/controllers/API/DocumentsController.js
@@ -65,8 +65,23 @@ module.exports = {
       },
     });
 
-    req.file('file').upload(async (err, uploadedFiles) => {
-      if (err) { return res.serverError(err); }
+    var settings = {
+      maxBytes: 10000000,
+    };
+
+    req.file('file').upload(settings, async (err, uploadedFiles) => {
+      if (err) {
+        if (err.code === 'E_EXCEEDS_UPLOAD_LIMIT') {
+          res.status(413);
+          return res.json(err.code);
+        }
+
+        return res.serverError(err);
+      }
+
+      if (uploadedFiles.length === 0) {
+        return res.badRequest('No file was uploaded');
+      }
 
       let file = uploadedFiles[0];
       let filename = path.basename(file.fd);

--- a/api/controllers/API/DocumentsController.js
+++ b/api/controllers/API/DocumentsController.js
@@ -6,6 +6,8 @@
  */
 
 const arrayHelpers = require('../../utils/ArrayHelpers');
+const path = require('path');
+const fs = require('fs');
 
 module.exports = {
   /**
@@ -22,7 +24,7 @@ module.exports = {
         {
           model: Document,
           as: 'Documents',
-          attributes: ['id', 'fileName'],
+          attributes: ['id', 'fileName', 'originalFileName'],
           include: [
             {
               model: Condition,
@@ -38,15 +40,13 @@ module.exports = {
       return res.send('Sorry, no report found. You may not be logged in.');
     }
 
-    let documents = [];
-
     // massage the data a bit
-    medicalReport.Documents.forEach((document) => {
-      documents.push({
+    let documents = medicalReport.Documents.map(document => {
+      return {
         id: document.id,
-        fileName: document.fileName,
+        fileName: document.originalFileName,
         conditions: arrayHelpers.pluckIds(document.Conditions)
-      });
+      };
     });
 
     res.send(documents);
@@ -65,12 +65,23 @@ module.exports = {
       },
     });
 
-    let document = await medicalReport.createDocument({
-      originalFileName: req.body.file,
-      fileName: req.body.file
-    });
+    req.file('file').upload(async (err, uploadedFiles) => {
+      if (err) { return res.serverError(err); }
 
-    res.send(document);
+      let file = uploadedFiles[0];
+      let filename = path.basename(file.fd);
+
+      let document = await medicalReport.createDocument({
+        originalFileName: file.filename,
+        fileName: filename
+      });
+
+      return res.json({
+        message: uploadedFiles.length + ' file(s) uploaded successfully!',
+        files: uploadedFiles,
+        document: document
+      });
+    });
   },
 
   /**
@@ -105,9 +116,16 @@ module.exports = {
       },
     });
 
-    await document.destroy();
+    const filePath = path.join(process.cwd(), '.tmp/uploads', document.fileName);
 
-    res.send('ok');
+    // delete from filesystem
+    fs.unlink(filePath, async (err) => {
+      if (err) { return console.log(err); }
+
+      await document.destroy();
+
+      res.ok();
+    });
   }
 };
 

--- a/assets/js/components/FileUpload.vue
+++ b/assets/js/components/FileUpload.vue
@@ -1,13 +1,17 @@
 <template>
   <div class="file">
     <input type="hidden" :name="fieldName" :value="JSON.stringify(uploaded_files)" />
-    <div class>
+    <div :class="uploadError.length ? 'pl-8 border-l-4 border-red-700' : ''">
       <label
         class="w-64 border-2 border-black cursor-pointer bg-gray-200 px-5 py-2 inline-block text-center"
       >
         <span>{{ this.uploadLabel }}</span>
         <input type="file" ref="file" @change="handleFileUpload" class="hidden" />
       </label>
+      <span v-show="uploadError.length" class="validation-message" id="file-error" role="alert">
+        <span class="visually-hidden">Error:</span>
+        {{ uploadError }}
+      </span>
     </div>
     <div class="mt-4">
       <div
@@ -29,7 +33,8 @@
 export default {
   data() {
     return {
-      uploaded_files: []
+      uploaded_files: [],
+      uploadError: []
     };
   },
   props: {
@@ -56,6 +61,7 @@ export default {
   },
   methods: {
     handleFileUpload() {
+      this.uploadError = [];
       const file = this.$refs.file.files[0];
       this.addFile(file);
     },
@@ -77,8 +83,8 @@ export default {
             fileName: response.data.document.originalFileName
           });
         })
-        .catch(error => {
-          console.log(error);
+        .catch(err => {
+          this.uploadError = err.response.data;
         });
     },
     removeFile(file) {

--- a/assets/js/components/FileUpload.vue
+++ b/assets/js/components/FileUpload.vue
@@ -6,7 +6,7 @@
         class="w-64 border-2 border-black cursor-pointer bg-gray-200 px-5 py-2 inline-block text-center"
       >
         <span>{{ this.uploadLabel }}</span>
-        <input type="file" ref="file" @change="onSelect" class="hidden" />
+        <input type="file" ref="file" @change="handleFileUpload" class="hidden" />
       </label>
     </div>
     <div class="mt-4">
@@ -55,33 +55,56 @@ export default {
     }
   },
   methods: {
-    onSelect() {
+    handleFileUpload() {
       const file = this.$refs.file.files[0];
-      this.addFile(file.name);
+      this.addFile(file);
     },
     addFile(file) {
+      let formData = new FormData();
+      formData.append("file", file);
+
+      // TODO: validate file is a file
+
       axios
-        .post("/api/documents", {
-          file: file
-        })
-        .then(response => {
-          this.uploaded_files.push({
-            id: response.data.id,
-            fileName: response.data.originalFileName
-          });
-        });
-    },
-    removeFile(file) {
-      // if we're editing vs creating
-      axios
-        .delete("/api/conditions/" + this.conditionId + "/documents", {
-          data: {
-            docId: file.id
+        .post("/api/documents", formData, {
+          headers: {
+            "Content-Type": "multipart/form-data"
           }
         })
         .then(response => {
-          this.uploaded_files.splice(this.uploaded_files.indexOf(file), 1);
+          this.uploaded_files.push({
+            id: response.data.document.id,
+            fileName: response.data.document.originalFileName
+          });
+        })
+        .catch(error => {
+          console.log(error);
         });
+    },
+    removeFile(file) {
+      if (this.conditionId) {
+        // on edit, we need to detach from the current condition
+        axios
+          .delete("/api/conditions/" + this.conditionId + "/documents", {
+            data: {
+              docId: file.id
+            }
+          })
+          .then(response => {
+            this.uploaded_files.splice(this.uploaded_files.indexOf(file), 1);
+          });
+      } else {
+        // on create, there is no Condition
+        axios
+          .delete("/api/documents", {
+            data: {
+              id: file.id
+            }
+          })
+          .then(response => {
+            this.uploaded_files.splice(this.uploaded_files.indexOf(file), 1);
+          });
+      }
     },
     getFiles(conditionId) {
       axios

--- a/assets/js/components/FileUpload.vue
+++ b/assets/js/components/FileUpload.vue
@@ -6,9 +6,16 @@
         class="w-64 border-2 border-black cursor-pointer bg-gray-200 px-5 py-2 inline-block text-center"
       >
         <span>{{ this.uploadLabel }}</span>
-        <input type="file" ref="file" @change="handleFileUpload" class="hidden" />
+        <input
+          type="file"
+          ref="file"
+          @change="handleFileUpload"
+          class="hidden"
+          :aria-describedby="uploadError.length > 0 ? 'file-error' : ''"
+          :aria-invalid="uploadError.length > 0"
+        />
       </label>
-      <span v-show="uploadError.length" class="validation-message" id="file-error" role="alert">
+      <span v-if="uploadError.length" class="validation-message" id="file-error" role="alert">
         <span class="visually-hidden">Error:</span>
         {{ uploadError }}
       </span>

--- a/assets/js/components/SupportingDocuments.vue
+++ b/assets/js/components/SupportingDocuments.vue
@@ -1,12 +1,16 @@
 <template>
   <div class="file">
-    <div class>
+    <div :class="uploadError.length ? 'pl-8 border-l-4 border-red-700' : ''">
       <label
         class="w-64 border-2 border-black cursor-pointer bg-gray-200 px-5 py-2 inline-block text-center"
       >
         <span>{{ this.uploadLabel }}</span>
         <input type="file" ref="file" @change="onSelect" class="hidden" />
       </label>
+      <span v-show="uploadError.length" class="validation-message" id="file-error" role="alert">
+        <span class="visually-hidden">Error:</span>
+        {{ uploadError }}
+      </span>
     </div>
 
     <div class="mt-4">
@@ -74,7 +78,8 @@ export default {
   data() {
     return {
       uploaded_files: [],
-      conditions: []
+      conditions: [],
+      uploadError: []
     };
   },
   props: {
@@ -97,16 +102,25 @@ export default {
   },
   methods: {
     onSelect() {
+      this.uploadError = [];
       const file = this.$refs.file.files[0];
-      this.addFile(file.name);
+      this.uploadFile(file);
     },
-    addFile(file) {
+    uploadFile(file) {
+      let formData = new FormData();
+      formData.append("file", file);
+
       axios
-        .post("/api/documents", {
-          file: file
+        .post("/api/documents", formData, {
+          headers: {
+            "Content-Type": "multipart/form-data"
+          }
         })
         .then(response => {
           this.updateFiles();
+        })
+        .catch(err => {
+          this.uploadError = err.response.data;
         });
     },
     removeFile(fileId) {

--- a/assets/js/components/SupportingDocuments.vue
+++ b/assets/js/components/SupportingDocuments.vue
@@ -5,9 +5,16 @@
         class="w-64 border-2 border-black cursor-pointer bg-gray-200 px-5 py-2 inline-block text-center"
       >
         <span>{{ this.uploadLabel }}</span>
-        <input type="file" ref="file" @change="onSelect" class="hidden" />
+        <input
+          type="file"
+          ref="file"
+          @change="onSelect"
+          class="hidden"
+          :aria-describedby="uploadError.length > 0 ? 'file-error' : ''"
+          :aria-invalid="uploadError.length > 0"
+        />
       </label>
-      <span v-show="uploadError.length" class="validation-message" id="file-error" role="alert">
+      <span v-if="uploadError.length" class="validation-message" id="file-error" role="alert">
         <span class="visually-hidden">Error:</span>
         {{ uploadError }}
       </span>
@@ -43,12 +50,14 @@
                     <div class="multiple-choice__item">
                       <input
                         type="checkbox"
-                        name="supportingDocuments"
+                        :id="'supportingDocuments_' + file.id + '_' + condition.id"
                         :value="condition.id"
                         v-model="file.conditions"
                         @change="saveConditions(file)"
                       />
-                      <label>{{ condition.conditionName }}</label>
+                      <label
+                        :for="'supportingDocuments_' + file.id + '_' + condition.id"
+                      >{{ condition.conditionName }}</label>
                     </div>
                   </li>
                 </ul>


### PR DESCRIPTION
# What this does

Enables the transfer of files from the client to the server (this behaviour was previously faked).
- Files are uploaded to `.tmp/uploads`
- File size limit currently (arbitrarily) set to 10Mb. Displays a validation error when files exceed this size.
- The file is renamed with a UUID for the filename to avoid collisions
- We store the originalFileName so we can later reference it in views and downloads
- When on Condition add/edit, deleting a file will behave differently depending on context:
    - On Add, deleting a file deletes the Document entry from the db and deletes the file
    - On Edit, the Document object is first detached from the Condition. Then, IF the document is not associated to any other Conditions, the Document object and file are deleted, otherwise it's left in place.
- When on the SupportingDocuments page, Delete will delete the Document object and the File.

## Validation

- Currently validating file size (10Mb)
    - What is a reasonable size limit to enforce?
- Should we be doing other types of validation? 
    - File mime type / file extension? 
    - What types? 
    - How do we confirm a file is of a type (ie, the extension hasn't been manipulated)?
- What kind of scanning are we going to be able to do post-upload?

## Notes on storage location

Files are currently uploaded to `.tmp/uploads` which means they're ephemeral - whenever Sails lifts, that folder will be cleared out.

I assume that we'll be able to mount Azure Blob storage at that mount point and make the files persist, otherwise we may need to change the upload directory.

For files to be accessible from the app, they need to be in that .tmp folder. So if we move them elsewhere, we can put them somewhere under assets/ which gets copied into .tmp at lift. 

Tricky thing would be making files available right away after upload would mean copying the file to both locations on upload.
