### PR TITLE
Revert baseURL change

### DIFF
--- a/config/custom.js
+++ b/config/custom.js
@@ -19,5 +19,5 @@ module.exports.custom = {
   // mailgunSecret: 'key-testkeyb183848139913858e8abd9a3',
   // stripeSecret: 'sk_test_Zzd814nldl91104qor5911gjald',
   // …
-  baseURL: process.env.BASE_URL || sails.getBaseUrl() || 'http://localhost:1337',
+  baseURL: process.env.BASE_URL || 'http://localhost:1337',
 };


### PR DESCRIPTION
This reverts a small change that came with a previous PR. The `sails.baseUrl()` method is not available in the config layer. Will have to find another way with this. PR to come.