### PR TITLE
Fix config so we can run in production mode

### DIFF
--- a/config/env/production.js
+++ b/config/env/production.js
@@ -250,10 +250,11 @@ module.exports = {
     * > Be sure to use the right protocol!  ("http://" vs. "https://")         *
     *                                                                          *
     ***************************************************************************/
-    // onlyAllowOrigins: [
-    //   'https://example.com',
-    //   'https://staging.example.com',
-    // ],
+    onlyAllowOrigins: [
+      process.env.BASE_URL
+      //   'https://example.com',
+      //   'https://staging.example.com',
+    ],
 
 
     /***************************************************************************


### PR DESCRIPTION
This fixes some config defaults so we can run the service in production mode. 

Basically just had to configure the allowedOrigins for web sockets - we're not using web sockets at the moment, so this doesn't really matter... just set it to the BASE_URL from the environment.

With this change, I was able to run `npm install --production` and then `npm run start` which brings the service up in production mode. I then ran the cypress tests, and everything is green.

