### PR TITLE
Enable Cypress to run inside headless container

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,6 +12,9 @@ RUN apk --no-cache add --virtual native-deps \
   g++ gcc libgcc libstdc++ linux-headers autoconf automake make nasm python git && \
   npm install --quiet node-gyp -g
 
+# Install XVFB to run Cypress tests headlessly
+RUN apk add xvfb
+
 # Copy code in for initial dependency build
 COPY . /app/
 

--- a/README.md
+++ b/README.md
@@ -200,3 +200,4 @@ This lets your development environment in the Docker image that resembles produc
 1. After it fully starts up, use the terminal embedded inside of VSCode to issue commands within the main container
 1. Run to set things up `npm install && npm run db:migrate && npm run db:seed`
 1. Run `npm run dev` to start the server
+  - To run automated tests after the server is up, use `npx cypress run`


### PR DESCRIPTION
This would enable us to run Cypress in the dev Docker image and also during PRs via a CI task.