### PR TITLE
Make the attachLater checkbox work for now

### DIFF
--- a/api/controllers/DocumentsController.js
+++ b/api/controllers/DocumentsController.js
@@ -50,10 +50,18 @@ module.exports = {
 
   store: async function (req, res) {
     /**
-     * We don't validate here because we need to be able to
-     * upload files even if conditions haven't been added yet.
-     * Validate on the Dashboard only.
+     * This should be replaced when we add the new docs
+     * screening question (like medications/treatments)
      */
+    let medicalReport = await MedicalReport.findOne({
+      where: {
+        applicationCode: req.session.applicationCode
+      },
+    });
+
+    await medicalReport.update({
+      patientDocuments: req.body.attachLater ? false : true
+    });
 
     res.redirect(sails.route('dashboard'));
   },

--- a/api/models/MedicalReport.js
+++ b/api/models/MedicalReport.js
@@ -97,6 +97,7 @@ module.exports = {
     workDetails: Sequelize.TEXT,
     patientMedications: Sequelize.BOOLEAN,
     patientTreatments: Sequelize.BOOLEAN,
+    patientDocuments: Sequelize.BOOLEAN,
     practitionerType: Sequelize.INTEGER, // fk to support
     practitionerTypeText: {
       type: Sequelize.VIRTUAL,

--- a/api/utils/DashboardHelpers.js
+++ b/api/utils/DashboardHelpers.js
@@ -31,6 +31,13 @@ function checkTreatements(medicalReport) {
   return isCollectionValid(medicalReport.Treatments);
 }
 
+function checkDocuments(medicalReport) {
+  if (medicalReport.patientDocuments === false) {
+    return true;
+  }
+  return medicalReport.Documents.length > 0;
+}
+
 const getValidationStatus = (medicalReport) => {
   return {
     personal: isValid(medicalReport, require('../schemas/relationship.schema')),
@@ -39,7 +46,7 @@ const getValidationStatus = (medicalReport) => {
     medications: checkMedications(medicalReport),
     treatments: checkTreatements(medicalReport),
     futureWork: isValid(medicalReport, require('../schemas/work.schema')),
-    supportingDocuments: isValid(medicalReport, require('../schemas/documents.schema')),
+    supportingDocuments: checkDocuments(medicalReport),
     practitioner: isValid(medicalReport, require('../schemas/practitioner.schema')),
   };
 };

--- a/database/migrations/20191119140928-create-medical-report.js
+++ b/database/migrations/20191119140928-create-medical-report.js
@@ -140,6 +140,9 @@ module.exports = {
       patientTreatments: {
         type: Sequelize.BOOLEAN
       },
+      patientDocuments: {
+        type: Sequelize.BOOLEAN
+      },
       practitionerType: {
         type: Sequelize.INTEGER
       },


### PR DESCRIPTION
# What this does
Makes the "attach later" checkbox on the Documents section work - if a doctor selects that box, a property will be set so that the dashboard will show that section as completed (so that attaching files is essentially optional)

Note that this will soon be replaced by screening functionality similar to the Medications/Treatments sections.