### PR TITLE
Add hint text for first condition name

### DIFF
--- a/views/pages/conditions/add_first.njk
+++ b/views/pages/conditions/add_first.njk
@@ -16,7 +16,7 @@
              # different depending on context (see add_first). The rest of
              # the form stays the same, so it's in a macro.
              #}
-            {{ conditionName('conditionName', 'add_condition.name_of_condition.first', medicalReport.fullName, { required: true, "autocomplete": "off", value: data.conditionName }) }}
+            {{ conditionName('conditionName', 'add_condition.name_of_condition.first', medicalReport.fullName, { required: true, "autocomplete": "off", value: data.conditionName, hint: 'add_condition.name_of_condition.first_hint' }) }}
 
             {{ conditionForm(data) }}
 


### PR DESCRIPTION
# What this does
Adds a bit of hint text to the first Condition name per the design

Figma:
![image](https://user-images.githubusercontent.com/1187115/76452492-9c3aaa00-63a7-11ea-9cb1-aba98d97f2ab.png)

Rendered:
![image](https://user-images.githubusercontent.com/1187115/76452530-a9579900-63a7-11ea-8127-446801fee989.png)


