### PR TITLE
Tag  on push to master, build container on tag

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,17 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: '0'
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@1.13.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true

--- a/.github/workflows/push_docker.yml
+++ b/.github/workflows/push_docker.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Get branch
         run: echo ::set-env name=BRANCH::$(echo ${GITHUB_REF:10})
       - name: Build Docker image
-        run: docker build -t ${{ secrets.AZURE_CONTAINER_REGISTRY_URL }}/cppd-medical-report-sails:${{env.BRANCH}} .
+        run: docker build -t ${{ secrets.AZURE_CONTAINER_REGISTRY_URL }}/cppd/node-app:${{env.BRANCH}} .
       - name: Publish Docker image
-        run: docker push ${{ secrets.AZURE_CONTAINER_REGISTRY_URL }}/cppd-medical-report-sails:${{env.BRANCH}}
+        run: docker push ${{ secrets.AZURE_CONTAINER_REGISTRY_URL }}/cppd/node-app:${{env.BRANCH}}


### PR DESCRIPTION
Unfortunately we can only test this when merging to master... :( 

This will tag any item pushed to master using this action: 
anothrNick/github-tag-action@1.13.0

Then when an item is tagged it should build a container and push it to the container registry tagged with the version number. 

