### PR TITLE
Add missing back button to Future Work Capacity

### DIFF
--- a/views/pages/work.njk
+++ b/views/pages/work.njk
@@ -6,6 +6,8 @@
 
 {% block content %}
 
+    {{ backButton('dashboard') }}
+
     <h1>{{ __('section6.title') }} <br/> <span class="text-base">{{ __('conditions.patient')}} {{ patientName(data) }}</span></h1>
 
     <div>


### PR DESCRIPTION
# What this does
The back button was missing on the Future work capacity section. Now it's there.

[Trello ticket](https://trello.com/c/76axfZCG/820-go-back-link-missing-from-future-work-capacity-header)