### PR TITLE
Set Node version to 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.11 AS base
+FROM node:12-alpine3.11 AS base
 
 # Versions
 # ARG NODE_VERSION=12.14.0 # Alpine 3.11 tracks NodeJS 12.x LTS
@@ -18,7 +18,7 @@ COPY package.json package-lock.json /app/
 # Install dependencies
 RUN npm install
 
-FROM node:lts-alpine3.11 AS final
+FROM node:12-alpine3.11 AS final
 WORKDIR /app
 
 # Install SailsJS

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,8 +1,4 @@
-FROM node:lts-alpine3.11
-
-# Versions
-# ARG NODE_VERSION=12.14.0 # Alpine 3.11 tracks NodeJS 12.x LTS
-# ARG NPM_VERSION=6.13.4 # Alpine 3.11 tracks NPM 6.x
+FROM node:12-alpine3.11
 
 ARG SAILS_VERISON=^1.0.0
 WORKDIR /app


### PR DESCRIPTION
The Dockerfile was tracking LTS, and silently migrated to a newer version of Node. The app doesn't seem to work yet (and/or just loads VERY slowly) with the latest LTS (14). Putting this in to stabilize the build at a set Node version so that someone can run it if they need to.